### PR TITLE
Beta 1.3.2b-1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,9 @@
-name: Client Continuous integration
+name: Client Continuous Integration
 
 on:
   push:
     branches:
-      - '*' 
+      - '*'
   pull_request:
     branches:
       - '*'
@@ -14,7 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: make
+      - name: gcc make
         run: make
-      - name: examples
+      - name: gcc examples
         run: make examples
+      - name: clean
+        run: make clean
+      - name: g++ make
+        run: make CC=g++
+      - name: g++ examples
+        run: make CC=g++ examples

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM gcc as builder
+
+WORKDIR /opt/client
+
+# client
+COPY . .
+RUN make -j4 && make examples
+
+############
+FROM ubuntu:bionic
+
+# install client
+COPY --from=builder /opt/client/bin/libclient.so /usr/local/lib/
+COPY --from=builder /opt/client/include/client /usr/local/include/client
+
+RUN ldconfig
+
+# client examples
+WORKDIR /home/client
+COPY --from=builder /opt/client/examples/bin ./examples
+
+CMD ["./examples/test"]

--- a/examples/admin.c
+++ b/examples/admin.c
@@ -252,6 +252,8 @@ static void end (int dummy) {
 	client_log_success ("Done!");
 	printf ("\n");
 
+	client_end ();
+
 	exit (0);
 
 }
@@ -260,6 +262,8 @@ int main (int argc, const char **argv) {
 
 	// register to the quit signal
 	signal (SIGINT, end);
+
+	client_init ();
 
 	cerver_client_version_print_full ();
 
@@ -276,6 +280,8 @@ int main (int argc, const char **argv) {
 			sleep (1);
 		}
 	}
+
+	client_end ();
 
 	return 0;
 

--- a/examples/admin.c
+++ b/examples/admin.c
@@ -59,12 +59,10 @@ static void client_event_connection_close (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_connection_close () - connection <%s> has been closed!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_warning (status);
-				free (status);
-			}
+			client_log_warning (
+				"client_event_connection_close () - connection <%s> has been closed!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -78,12 +76,10 @@ static void client_error_failed_auth (void *client_error_data_ptr) {
 		ClientErrorData *client_error_data = (ClientErrorData *) client_error_data_ptr;
 
 		if (client_error_data->connection) {
-			char *status = c_string_create ("client_error_failed_auth () - connection <%s> failed to authenticate!",
-				client_error_data->connection->name->str);
-			if (status) {
-				client_log_error (status);
-				free (status);
-			}
+			client_log_error (
+				"client_error_failed_auth () - connection <%s> failed to authenticate!",
+				client_error_data->connection->name->str
+			);
 		}
 
 		client_error_data_delete (client_error_data);
@@ -97,12 +93,10 @@ static void client_event_success_auth (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_success_auth () - connection <%s> has been authenticated!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_success (status);
-				free (status);
-			}
+			client_log_success (
+				"client_event_success_auth () - connection <%s> has been authenticated!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -157,22 +151,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
 				);
 
 				if (!client_connect_and_start (client, connection)) {
-					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 					retval = 0;
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 				}
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 		}
 	}
 
@@ -200,10 +194,10 @@ static void app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 		
 		switch (packet->header->request_type) {
-			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			default: 
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -224,7 +218,7 @@ static int test_msg_send (void) {
 			packet_set_network_values (packet, client, connection);
 			size_t sent = 0;
 			if (packet_send (packet, 0, &sent, false)) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
 			}
 
 			else {

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -59,12 +59,10 @@ static void client_event_connection_close (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_connection_close () - connection <%s> has been closed!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_warning (status);
-				free (status);
-			}
+			client_log_warning (
+				"client_event_connection_close () - connection <%s> has been closed!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -78,12 +76,10 @@ static void client_event_auth_sent (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_auth_sent () - sent connection <%s> auth data!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_debug (status);
-				free (status);
-			}
+			client_log_debug (
+				"client_event_auth_sent () - sent connection <%s> auth data!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -97,12 +93,10 @@ static void client_error_failed_auth (void *client_error_data_ptr) {
 		ClientErrorData *client_error_data = (ClientErrorData *) client_error_data_ptr;
 
 		if (client_error_data->connection) {
-			char *status = c_string_create ("client_error_failed_auth () - connection <%s> failed to authenticate!",
-				client_error_data->connection->name->str);
-			if (status) {
-				client_log_error (status);
-				free (status);
-			}
+			client_log_error (
+				"client_error_failed_auth () - connection <%s> failed to authenticate!",
+				client_error_data->connection->name->str
+			);
 		}
 
 		client_error_data_delete (client_error_data);
@@ -116,12 +110,10 @@ static void client_event_success_auth (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_success_auth () - connection <%s> has been authenticated!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_success (status);
-				free (status);
-			}
+			client_log_success (
+				"client_event_success_auth () - connection <%s> has been authenticated!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -183,22 +175,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
 				);
 
 				if (!client_connect_and_start (client, connection)) {
-					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 					retval = 0;
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 				}
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 		}
 	}
 
@@ -226,10 +218,10 @@ static void app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 		
 		switch (packet->header->request_type) {
-			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			default: 
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -250,7 +242,7 @@ static int test_msg_send (void) {
 			packet_set_network_values (packet, client, connection);
 			size_t sent = 0;
 			if (packet_send (packet, 0, &sent, false)) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
 			}
 
 			else {

--- a/examples/auth.c
+++ b/examples/auth.c
@@ -278,6 +278,8 @@ static void end (int dummy) {
 	client_log_success ("Done!");
 	printf ("\n");
 
+	client_end ();
+
 	exit (0);
 
 }
@@ -286,6 +288,8 @@ int main (int argc, const char **argv) {
 
 	// register to the quit signal
 	signal (SIGINT, end);
+
+	client_init ();
 
 	cerver_client_version_print_full ();
 
@@ -302,6 +306,8 @@ int main (int argc, const char **argv) {
 			sleep (1);
 		}
 	}
+
+	client_end ();
 
 	return 0;
 

--- a/examples/balancer.c
+++ b/examples/balancer.c
@@ -1,0 +1,304 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <unistd.h>
+#include <signal.h>
+
+#include "client/version.h"
+
+#include "client/types/string.h"
+
+#include "client/client.h"
+#include "client/packets.h"
+#include "client/timer.h"
+
+#include "client/utils/log.h"
+
+static Client *client = NULL;
+static Connection *connection = NULL;
+
+static void app_handler (void *packet_ptr);
+
+#pragma region app
+
+#define APP_MESSAGE_LEN			512
+
+#define MESSAGE_0				"Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua."
+#define MESSAGE_1				"Sagittis nisl rhoncus mattis rhoncus urna. Vitae congue eu consequat ac felis donec et odio. "
+#define MESSAGE_2				"Commodo sed egestas egestas fringilla phasellus. Tellus id interdum velit laoreet id donec ultrices tincidunt. Porttitor massa id neque aliquam vestibulum morbi blandit cursus."
+#define MESSAGE_3				"Malesuada pellentesque elit eget gravida cum. Pharetra vel turpis nunc eget lorem dolor sed viverra."
+#define MESSAGE_4				"Justo donec enim diam vulputate. Dui nunc mattis enim ut. Quis vel eros donec ac odio tempor. Lorem ipsum dolor sit amet consectetur."
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0,
+	APP_MSG			= 1,
+	MULTI_MSG		= 2,
+
+} AppRequest;
+
+typedef struct AppData {
+
+	time_t timestamp;
+	size_t message_len;
+	char message[APP_MESSAGE_LEN];
+
+} AppData;
+
+static void app_data_print (AppData *app_data) {
+
+	if (app_data) {
+		String *date = timer_time_to_string (gmtime (&app_data->timestamp));
+		if (date) {
+			printf ("Timestamp: %s\n", date->str);
+			str_delete (date);
+		}
+
+		printf ("Message (%ld): %s\n", app_data->message_len, app_data->message);
+	}
+
+}
+
+#pragma endregion
+
+#pragma region connect
+
+static int cerver_connect (const char *ip, unsigned int port) {
+
+	int retval = 1;
+
+	if (ip) {
+		fprintf (stdout, "\nConnecting to cerver...\n");
+
+		client = client_create ();
+		if (client) {
+			client_set_app_handlers (client, app_handler, NULL);
+
+			connection = client_connection_create (client, ip, port, PROTOCOL_TCP, false);
+			if (connection) {
+				connection_set_name (connection, "main");
+				connection_set_max_sleep (connection, 30);
+
+				if (!client_connect_and_start (client, connection)) {
+					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					retval = 0;
+				}
+
+				else {
+					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				}
+			}
+
+			else {
+				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+			}
+		}
+
+		else {
+			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+		}
+	}
+
+	return retval;
+
+}
+
+static void cerver_disconnect (void) {
+
+	client_connection_end (client, connection);
+
+	if (!client_teardown (client)) {
+		client_log_success ("client_teardown ()!");
+	}
+
+}
+
+#pragma endregion
+
+#pragma region handler
+
+static void handle_app_message (Packet *packet) {
+
+	if (packet) {
+		char *end = (char *) packet->data;
+
+		AppData *app_data = (AppData *) end;
+		app_data_print (app_data);
+		printf ("\n");
+	}
+
+}
+
+static void app_handler (void *packet_ptr) {
+
+	if (packet_ptr) {
+		Packet *packet = (Packet *) packet_ptr;
+		
+		switch (packet->header->request_type) {
+			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+
+			case APP_MSG: handle_app_message (packet); break;
+
+			default: 
+				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				break;
+		}
+	}
+
+}
+
+#pragma endregion
+
+#pragma region request
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
+
+static unsigned int send_packet (Packet *packet) {
+
+	unsigned int retval = 1;
+
+	if (packet) {
+		packet_set_network_values (packet, client, connection);
+		size_t sent = 0;
+		if (packet_send (packet, 0, &sent, false)) {
+			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
+		}
+
+		else {
+			printf ("Sent to cerver: %ld\n", sent);
+			retval = 0;
+		}
+	}
+
+	return retval;
+
+}
+
+static unsigned int test_msg_send (void) {
+
+	unsigned int retval = 1;
+
+	if ((client->running) && (connection->connected)) {
+		Packet *packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
+		if (packet) {
+			retval = send_packet (packet);
+
+			packet_delete (packet);
+		}
+	}
+
+	return retval;
+
+}
+
+static unsigned int app_msg_send_generate_manual (const char *message) {
+
+	unsigned int retval = 1;
+
+	if (message) {
+		Packet *req = packet_new ();
+		if (req) {
+			size_t packet_len = sizeof (PacketHeader) + sizeof (AppData);
+			req->packet = malloc (packet_len);
+			req->packet_size = packet_len;
+
+			char *end = (char *) req->packet;
+			PacketHeader *header = (PacketHeader *) end;
+			header->packet_type = PACKET_TYPE_APP;
+			header->packet_size = packet_len;
+
+			header->request_type = APP_MSG;
+
+			end += sizeof (PacketHeader);
+
+			AppData *app_data = (AppData *) end;
+			memset (app_data, 0, sizeof (AppData));
+			time (&app_data->timestamp);
+
+			if (message) {
+				app_data->message_len = strlen (message);
+				strncpy (app_data->message, message, APP_MESSAGE_LEN);
+			}
+
+			send_packet (req);
+
+			packet_delete (req);
+		}
+	}
+
+	return retval;
+
+}
+
+#pragma GCC diagnostic pop
+
+#pragma endregion
+
+#pragma region main
+
+static void end (int dummy) {
+	
+	cerver_disconnect ();
+
+	printf ("\n");
+	client_log_success ("Done!");
+	printf ("\n");
+
+	exit (0);
+
+}
+
+int main (int argc, const char **argv) {
+
+	// register to the quit signal
+	signal (SIGINT, end);
+
+	cerver_client_version_print_full ();
+
+	client_log_debug ("Packets Example");
+	printf ("\n");
+
+	String *messages[5];
+	messages[0] = str_new (MESSAGE_0);
+	messages[1] = str_new (MESSAGE_1);
+	messages[2] = str_new (MESSAGE_2);
+	messages[3] = str_new (MESSAGE_3);
+	messages[4] = str_new (MESSAGE_4);
+
+	if (!cerver_connect ("127.0.0.1", 7000)) {
+		sleep (1);
+
+		int idx = 0;
+		while (1) {
+			// printf ("test_msg_send ()\n");
+			// test_msg_send ();
+			// printf ("\n");
+
+			printf ("app_msg_send_generate_manual ()\n");
+			app_msg_send_generate_manual (messages[idx]->str);
+			printf ("\n");
+
+			sleep (1);
+
+			idx += 1;
+			if (idx > 4) idx = 0;
+		}
+
+		sleep (1);
+
+		cerver_disconnect ();
+	}
+
+	str_delete (messages[0]);
+	str_delete (messages[1]);
+	str_delete (messages[2]);
+	str_delete (messages[3]);
+	str_delete (messages[4]);
+
+	return 0;
+
+}
+
+#pragma endregion

--- a/examples/balancer.c
+++ b/examples/balancer.c
@@ -81,22 +81,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
 				connection_set_max_sleep (connection, 30);
 
 				if (!client_connect_and_start (client, connection)) {
-					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 					retval = 0;
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 				}
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 		}
 	}
 
@@ -136,12 +136,12 @@ static void app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 		
 		switch (packet->header->request_type) {
-			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			case APP_MSG: handle_app_message (packet); break;
 
 			default: 
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -163,7 +163,7 @@ static unsigned int send_packet (Packet *packet) {
 		packet_set_network_values (packet, client, connection);
 		size_t sent = 0;
 		if (packet_send (packet, 0, &sent, false)) {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
 		}
 
 		else {

--- a/examples/files.c
+++ b/examples/files.c
@@ -44,12 +44,10 @@ static void client_event_connection_close (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_connection_close () - connection <%s> has been closed!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_warning (status);
-				free (status);
-			}
+			client_log_warning (
+				"client_event_connection_close () - connection <%s> has been closed!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -92,22 +90,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
 				connection_set_max_sleep (connection, 30);
 
 				if (!client_connect_and_start (client, connection)) {
-					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 					retval = 0;
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 				}
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 		}
 	}
 
@@ -135,10 +133,10 @@ static void app_handler (void *packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
         if (packet) {
             switch (packet->header->request_type) {
-                case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+                case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
                 default: 
-                    client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                    client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
                     break;
             }
         }
@@ -160,7 +158,7 @@ static int test_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {
@@ -244,13 +242,9 @@ static void start (const char *action, const char *filename) {
 		if (!strcmp ("get", action)) request_file (filename);
 		else if (!strcmp ("send", action)) send_file (filename);
 		else {
-			char *status = c_string_create ("Unknown action %s", action);
-			if (status) {
-				printf ("\n");
-				client_log_error (status);
-				printf ("\n");
-				free (status);
-			}
+			printf ("\n");
+			client_log_error ("Unknown action %s", action);
+			printf ("\n");
 		}
 
 		for (unsigned int i = 0; i < 10; i++) {

--- a/examples/files.c
+++ b/examples/files.c
@@ -155,6 +155,8 @@ static void end (int dummy) {
 	client_log_success ("Done!");
 	printf ("\n");
 
+	client_end ();
+
 	exit (0);
 
 }
@@ -197,6 +199,8 @@ static void start (const char *action, const char *filename) {
 
 int main (int argc, const char **argv) {
 
+	client_init ();
+
 	if (argc >= 3) {
 		start (argv[1], argv[2]);
 	}
@@ -204,6 +208,8 @@ int main (int argc, const char **argv) {
 	else {
 		printf ("\nUsage: %s get/send [filename]\n\n", argv[0]);
 	}
+
+	client_end ();
 
 	return 0;
 

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -47,22 +47,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
                 connection_set_max_sleep (connection, 30);
 
                 if (!client_connect_and_start (client, connection)) {
-                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
                     retval = 0;
                 }
 
                 else {
-                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                    client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
                 }
             }
 
             else {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
             }
         }
 
         else {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
         }
     }
 
@@ -92,7 +92,7 @@ static void my_app_handler (void *data) {
                 break;
 
             default: 
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_APP request.");
+                client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_APP request.");
                 break;
         }
 	}
@@ -109,7 +109,7 @@ static void my_app_error_handler (void *data) {
                 break;
 
             default: 
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_APP_ERROR request.");
+                client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_APP_ERROR request.");
                 break;
         }
 	}
@@ -126,7 +126,7 @@ static void my_custom_handler (void *data) {
                 break;
 
             default: 
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_CUSTOM request.");
+                client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown PACKET_TYPE_CUSTOM request.");
                 break;
         }
 	}
@@ -147,7 +147,7 @@ static int test_app_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {
@@ -173,7 +173,7 @@ static int test_app_error_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {
@@ -199,7 +199,7 @@ static int test_custom_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {

--- a/examples/handlers.c
+++ b/examples/handlers.c
@@ -227,6 +227,8 @@ static void end (int dummy) {
     client_log_success ("Done!");
     printf ("\n");
 
+    client_end ();
+
 	exit (0);
 
 }
@@ -235,6 +237,8 @@ int main (int argc, const char **argv) {
 
     // register to the quit signal
 	signal (SIGINT, end);
+
+    client_init ();
 
     cerver_client_version_print_full ();
 
@@ -252,6 +256,8 @@ int main (int argc, const char **argv) {
             sleep (1);
         }
     }
+
+    client_end ();
 
     return 0;
 

--- a/examples/logs.c
+++ b/examples/logs.c
@@ -40,22 +40,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
                 connection_set_max_sleep (connection, 30);
 
                 if (!client_connect_and_start (client, connection)) {
-                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
                     retval = 0;
                 }
 
                 else {
-                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                    client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
                 }
             }
 
             else {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
             }
         }
 
         else {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
         }
     }
 
@@ -83,10 +83,10 @@ static void app_handler (void *packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
         if (packet) {
             switch (packet->header->request_type) {
-                case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+                case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
                 default: 
-                    client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                    client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
                     break;
             }
         }
@@ -108,7 +108,7 @@ static int test_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {

--- a/examples/logs.c
+++ b/examples/logs.c
@@ -1,0 +1,172 @@
+#include <stdio.h>
+
+#include <unistd.h>
+#include <signal.h>
+
+#include "client/version.h"
+
+#include "client/client.h"
+#include "client/packets.h"
+
+#include "client/utils/log.h"
+
+typedef enum AppRequest {
+
+	TEST_MSG		= 0
+
+} AppRequest;
+
+static Client *client = NULL;
+static Connection *connection = NULL;
+
+static void app_handler (void *packet_ptr);
+
+#pragma region connect
+
+static int cerver_connect (const char *ip, unsigned int port) {
+
+    int retval = 1;
+
+    if (ip) {
+        fprintf (stdout, "\nConnecting to cerver...\n");
+
+        client = client_create ();
+        if (client) {
+            client_set_app_handlers (client, app_handler, NULL);
+
+            connection = client_connection_create (client, ip, port, PROTOCOL_TCP, false);
+            if (connection) {
+                connection_set_name (connection, "main");
+                connection_set_max_sleep (connection, 30);
+
+                if (!client_connect_and_start (client, connection)) {
+                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    retval = 0;
+                }
+
+                else {
+                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                }
+            }
+
+            else {
+                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+            }
+        }
+
+        else {
+            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+        }
+    }
+
+    return retval;
+
+}
+
+static void cerver_disconnect (void) {
+
+    client_connection_end (client, connection);
+
+    if (!client_teardown (client)) {
+        client_log_success ("client_teardown ()!");
+    }
+
+}
+
+#pragma endregion
+
+#pragma region handler
+
+static void app_handler (void *packet_ptr) {
+
+	if (packet_ptr) {
+        Packet *packet = (Packet *) packet_ptr;
+        if (packet) {
+            switch (packet->header->request_type) {
+                case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+
+                default: 
+                    client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                    break;
+            }
+        }
+    }
+
+}
+
+#pragma endregion
+
+#pragma region request
+
+static int test_msg_send (void) {
+
+    int retval = 1;
+
+    if ((client->running) && (connection->connected)) {
+        Packet *packet = packet_generate_request (PACKET_TYPE_APP, TEST_MSG, NULL, 0);
+        if (packet) {
+            packet_set_network_values (packet, client, connection);
+            size_t sent = 0;
+            if (packet_send (packet, 0, &sent, false)) {
+                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+            }
+
+            else {
+                printf ("Test sent to cerver: %ld\n", sent);
+                retval = 0;
+            } 
+
+            packet_delete (packet);
+        }
+    }
+
+    return retval;
+
+}
+
+#pragma endregion
+
+#pragma region main
+
+static void end (int dummy) {
+	
+	cerver_disconnect ();
+
+    printf ("\n");
+    client_log_success ("Done!");
+    printf ("\n");
+
+    client_end ();
+
+	exit (0);
+
+}
+
+int main (int argc, const char **argv) {
+
+    // register to the quit signal
+	signal (SIGINT, end);
+
+    client_init ();
+
+    cerver_client_version_print_full ();
+
+    client_log_debug ("Basic test client example with custom logs configurations");
+	printf ("\n");
+
+    if (!cerver_connect ("127.0.0.1", 7000)) {
+        // send a test message every second
+        while (1) {
+            test_msg_send ();
+
+            sleep (1);
+        }
+    }
+
+    client_end ();
+
+    return 0;
+
+}
+
+#pragma endregion

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -52,22 +52,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
                 connection_set_max_sleep (connection, 30);
                 
                 if (!client_connect_and_start (client, connection)) {
-                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
                     retval = 0;
                 }
 
                 else {
-                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                    client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
                 }
             }
 
             else {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
             }
         }
 
         else {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
         }
     }
 
@@ -93,7 +93,7 @@ static void app_handler (void *packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
 
         switch (packet->header->request_type) {
-            case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+            case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
             case GET_MSG: {
                 char *end = (char *) packet->data;
@@ -103,7 +103,7 @@ static void app_handler (void *packet_ptr) {
             } break;
 
             default: 
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
                 break;
         }
     }
@@ -146,7 +146,7 @@ static int test_msg_send (void) {
 
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {
@@ -192,7 +192,7 @@ static int request_message (void) {
 
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
             }
 
             else {

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -221,6 +221,8 @@ static void end (int dummy) {
     client_log_success ("Done!");
     printf ("\n");
 
+    client_end ();
+
 	exit (0);
 
 }
@@ -229,6 +231,8 @@ int main (int argc, const char **argv) {
 
     // register to the quit signal
 	signal (SIGINT, end);
+
+    client_init ();
 
     cerver_client_version_print_full ();
 
@@ -246,6 +250,8 @@ int main (int argc, const char **argv) {
             sleep (1);
         }
     }
+
+    client_end ();
 
     return 0;
 

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -285,7 +285,7 @@ static unsigned int app_msg_send_generate_split (const char *message) {
 			packet->data = malloc (data_size);
 			packet->data_size = data_size;
 			
-			char *end = packet->data;
+			char *end = (char *) packet->data;
 			AppData *app_data = (AppData *) end;
 			memset (app_data, 0, sizeof (AppData));
 			time (&app_data->timestamp);
@@ -330,7 +330,7 @@ static unsigned int app_msg_send_generate_pieces (void) {
 
 		packet->header->request_type = MULTI_MSG;
 
-		void **messages = calloc (n_messages, sizeof (AppData));
+		void **messages = (void **) calloc (n_messages, sizeof (AppData));
 		size_t *sizes = (size_t *) calloc (n_messages, sizeof (size_t));
 		if (messages && sizes) {
 			for (u32 i = 0; i < n_messages; i++) {

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -99,22 +99,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
 				connection_set_max_sleep (connection, 30);
 
 				if (!client_connect_and_start (client, connection)) {
-					client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+					client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 					retval = 0;
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 				}
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 		}
 	}
 
@@ -142,10 +142,10 @@ static void app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 		
 		switch (packet->header->request_type) {
-			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			default: 
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -167,7 +167,7 @@ static unsigned int send_packet (Packet *packet) {
 		packet_set_network_values (packet, client, connection);
 		size_t sent = 0;
 		if (packet_send (packet, 0, &sent, false)) {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
 		}
 
 		else {
@@ -298,7 +298,7 @@ static unsigned int app_msg_send_generate_split (const char *message) {
 			packet_set_network_values (packet, client, connection);
 			size_t sent = 0;
 			if (packet_send_split (packet, 0, &sent)) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
 			}
 
 			else {
@@ -373,7 +373,7 @@ static unsigned int app_msg_send_generate_pieces (void) {
 			packet_set_network_values (packet, client, connection);
 			size_t sent = 0;
 			if (packet_send_pieces (packet, messages, sizes, n_messages, 0, &sent)) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send packet!");
 			}
 
 			else {

--- a/examples/packets.c
+++ b/examples/packets.c
@@ -408,6 +408,8 @@ static void end (int dummy) {
 	client_log_success ("Done!");
 	printf ("\n");
 
+	client_end ();
+
 	exit (0);
 
 }
@@ -416,6 +418,8 @@ int main (int argc, const char **argv) {
 
 	// register to the quit signal
 	signal (SIGINT, end);
+
+	client_init ();
 
 	cerver_client_version_print_full ();
 
@@ -457,6 +461,8 @@ int main (int argc, const char **argv) {
 	}
 
 	str_delete (message);
+
+	client_end ();
 
 	return 0;
 

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -159,6 +159,8 @@ static void end (int dummy) {
     client_log_success ("Done!");
     printf ("\n");
 
+    client_end ();
+
 	exit (0);
 
 }
@@ -167,6 +169,8 @@ int main (int argc, const char **argv) {
 
     // register to the quit signal
 	signal (SIGINT, end);
+
+    client_init ();
 
     cerver_client_version_print_full ();
 
@@ -180,6 +184,8 @@ int main (int argc, const char **argv) {
             sleep (1);
         }
     }
+
+    client_end ();
 
     return 0;
 

--- a/examples/requests.c
+++ b/examples/requests.c
@@ -52,22 +52,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
                 connection_set_max_sleep (connection, 30);
                 
                 if (!client_connect_to_cerver (client, connection)) {
-                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
                     retval = 0;
                 }
 
                 else {
-                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                    client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
                 }
             }
 
             else {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
             }
         }
 
         else {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
         }
     }
 
@@ -94,7 +94,7 @@ static void app_handler (void *packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
         
         switch (packet->header->request_type) {
-            case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+            case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
             case GET_MSG: {
                 char *end = (char *) packet->data;
@@ -104,7 +104,7 @@ static void app_handler (void *packet_ptr) {
             } break;
 
             default: 
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
                 break;
         }
     }
@@ -136,7 +136,7 @@ static int request_message (void) {
 
         printf ("Requesting to cerver...\n");
         if (client_request_to_cerver (client, connection, packet)) {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send message request to cerver");
         }
         printf ("Request has ended\n");
 

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -309,6 +309,8 @@ static void end (int dummy) {
 	client_log_success ("Done!");
 	printf ("\n");
 
+	client_end ();
+
 	exit (0);
 
 }
@@ -317,6 +319,8 @@ int main (int argc, const char **argv) {
 
 	// register to the quit signal
 	signal (SIGINT, end);
+
+	client_init ();
 
 	cerver_client_version_print_full ();
 
@@ -339,6 +343,8 @@ int main (int argc, const char **argv) {
 			sleep (1);
 		}
 	}
+
+	client_end ();
 
 	return 0;
 

--- a/examples/sessions.c
+++ b/examples/sessions.c
@@ -65,12 +65,10 @@ static void client_event_connection_close (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_connection_close () - connection <%s> has been closed!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_warning (status);
-				free (status);
-			}
+			client_log_warning (
+				"client_event_connection_close () - connection <%s> has been closed!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		client_event_data_delete (client_event_data);
@@ -84,12 +82,10 @@ static void client_error_failed_auth (void *client_error_data_ptr) {
 		ClientErrorData *client_error_data = (ClientErrorData *) client_error_data_ptr;
 
 		if (client_error_data->connection) {
-			char *status = c_string_create ("client_error_failed_auth () - connection <%s> failed to authenticate!",
-				client_error_data->connection->name->str);
-			if (status) {
-				client_log_error (status);
-				free (status);
-			}
+			client_log_error (
+				"client_error_failed_auth () - connection <%s> failed to authenticate!",
+				client_error_data->connection->name->str
+			);
 		}
 
 		client_error_data_delete (client_error_data);
@@ -103,12 +99,10 @@ static void client_event_success_auth (void *client_event_data_ptr) {
 		ClientEventData *client_event_data = (ClientEventData *) client_event_data_ptr;
 
 		if (client_event_data->connection) {
-			char *status = c_string_create ("client_event_success_auth () - connection <%s> has been authenticated!",
-				client_event_data->connection->name->str);
-			if (status) {
-				client_log_success (status);
-				free (status);
-			}
+			client_log_success (
+				"client_event_success_auth () - connection <%s> has been authenticated!",
+				client_event_data->connection->name->str
+			);
 		}
 
 		if (!connection_with_session_id) {
@@ -168,22 +162,22 @@ static int cerver_connect (void) {
 			);
 
 			if (!client_connect_and_start (client, connection)) {
-				client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+				client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 				retval = 0;
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 			}
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 		}
 	}
 
 	else {
-		client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+		client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
 	}
 
 	return retval;
@@ -214,12 +208,12 @@ static u8 cerver_connect_with_session_id (void) {
 			);
 
 			if (!client_connect_and_start (client, connection_with_session_id)) {
-				client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+				client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
 				retval = 0;
 			}
 
 			else {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
 			}
 		}
 
@@ -229,7 +223,7 @@ static u8 cerver_connect_with_session_id (void) {
 	}
 
 	else {
-		client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+		client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
 	}
 
 	return retval;
@@ -257,10 +251,10 @@ static void app_handler (void *packet_ptr) {
 		Packet *packet = (Packet *) packet_ptr;
 
 		switch (packet->header->request_type) {
-			case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+			case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
 			default: 
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
 				break;
 		}
 	}
@@ -281,7 +275,7 @@ static int test_msg_send (Connection *con) {
 			packet_set_network_values (packet, client, con);
 			size_t sent = 0;
 			if (packet_send (packet, 0, &sent, false)) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
 			}
 
 			else {

--- a/examples/test.c
+++ b/examples/test.c
@@ -40,22 +40,22 @@ static int cerver_connect (const char *ip, unsigned int port) {
                 connection_set_max_sleep (connection, 30);
 
                 if (!client_connect_and_start (client, connection)) {
-                    client_log_msg (stdout, LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
+                    client_log (LOG_TYPE_SUCCESS, LOG_TYPE_NONE, "Connected to cerver!");
                     retval = 0;
                 }
 
                 else {
-                    client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
+                    client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to connect to cerver!");
                 }
             }
 
             else {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create connection!");
             }
         }
 
         else {
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
+            client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create client!");
         }
     }
 
@@ -83,10 +83,10 @@ static void app_handler (void *packet_ptr) {
         Packet *packet = (Packet *) packet_ptr;
         if (packet) {
             switch (packet->header->request_type) {
-                case TEST_MSG: client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
+                case TEST_MSG: client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Got a test message from cerver!"); break;
 
                 default: 
-                    client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
+                    client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Got an unknown app request.");
                     break;
             }
         }
@@ -108,7 +108,7 @@ static int test_msg_send (void) {
             packet_set_network_values (packet, client, connection);
             size_t sent = 0;
             if (packet_send (packet, 0, &sent, false)) {
-                client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
+                client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to send test to cerver");
             }
 
             else {

--- a/examples/test.c
+++ b/examples/test.c
@@ -136,6 +136,8 @@ static void end (int dummy) {
     client_log_success ("Done!");
     printf ("\n");
 
+    client_end ();
+
 	exit (0);
 
 }
@@ -144,6 +146,8 @@ int main (int argc, const char **argv) {
 
     // register to the quit signal
 	signal (SIGINT, end);
+
+    client_init ();
 
     cerver_client_version_print_full ();
 
@@ -167,6 +171,8 @@ int main (int argc, const char **argv) {
 
         // cerver_disconnect ();
     }
+
+    client_end ();
 
     return 0;
 

--- a/include/client/client.h
+++ b/include/client/client.h
@@ -23,6 +23,18 @@ struct _Packet;
 struct _PacketsPerType;
 struct _FileHeader;
 
+#pragma region global
+
+// initializes global client values
+// should be called only once at the start of the program
+CLIENT_EXPORT void client_init (void);
+
+// correctly disposes global values
+// should be called only once at the very end of the program
+CLIENT_EXPORT void client_end (void);
+
+#pragma endregion
+
 #pragma region stats
 
 struct _ClientStats {

--- a/include/client/client.h
+++ b/include/client/client.h
@@ -113,7 +113,9 @@ struct _Client {
 
 	u8 (*file_upload_handler) (
 		struct _Client *, struct _Connection *,
-		struct _FileHeader *, char **saved_filename
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
 	);
 
 	void (*file_upload_cb) (
@@ -271,7 +273,9 @@ CLIENT_EXPORT void client_files_set_file_upload_handler (
 	Client *client,
 	u8 (*file_upload_handler) (
 		struct _Client *, struct _Connection *,
-		struct _FileHeader *, char **saved_filename
+		struct _FileHeader *,
+		const char *file_data, size_t file_data_len,
+		char **saved_filename
 	)
 );
 

--- a/include/client/collections/pool.h
+++ b/include/client/collections/pool.h
@@ -2,15 +2,30 @@
 #define _COLLECTIONS_POOL_H_
 
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "client/collections/dlist.h"
 
 typedef struct Pool {
 
 	DoubleList *dlist;
+
 	void (*destroy)(void *data);
+	void *(*create)(void);
+
+	bool produce;
 
 } Pool;
+
+// sets a destroy method to be used by the pool to correctly dispose data
+extern void pool_set_destroy (Pool *pool, void (*destroy)(void *data));
+
+// sets a create method to be used by the pool to correctly allocate new data
+extern void pool_set_create (Pool *pool, void *(*create)(void));
+
+// sets the pool's ability to produce a element when a pop request is done and the pool is empty
+// the pool will use its create method to allocate a new element and fullfil the request
+extern void pool_set_produce_if_empty (Pool *pool, bool produce);
 
 // returns how many elements are inside the pool
 extern size_t pool_size (Pool *pool);
@@ -18,26 +33,28 @@ extern size_t pool_size (Pool *pool);
 // creates a new pool
 extern Pool *pool_create (void (*destroy)(void *data));
 
-// uses the create method to populate the pool with n elements
+// uses the create method to populate the pool with n elements (NULL to use pool's set method)
 // returns 0 on no error, 1 if at least one element failed to be inserted
-extern int pool_init (Pool *pool,
-	void *(*create)(void), unsigned int n_elements);
+extern int pool_init (
+	Pool *pool,
+	void *(*create)(void), unsigned int n_elements
+);
 
-// deletes the pool and all of its members using the destroy method
-extern void pool_delete (Pool *pool);
+// inserts the new data at the end of the pool
+// returns 0 on success, 1 on error
+extern int pool_push (Pool *pool, void *data);
 
-// destroys all of the pool's elements and their data but keeps the pool
-extern void pool_reset (Pool *pool);
+// returns the data that is first in the pool
+extern void *pool_pop (Pool *pool);
 
 // only gets rid of the pool's elements, but the data is kept
 // this is usefull if another structure points to the same data
 extern void pool_clear (Pool *pool);
 
-// inserts the new data at the end of the pool
-// returns 0 on success, 1 on error
-extern unsigned int pool_push (Pool *pool, void *data);
+// destroys all of the pool's elements and their data but keeps the pool
+extern void pool_reset (Pool *pool);
 
-// returns the data that is first in the pool
-extern void *pool_pop (Pool *pool);
+// deletes the pool and all of its members using the destroy method
+extern void pool_delete (Pool *pool);
 
 #endif

--- a/include/client/connection.h
+++ b/include/client/connection.h
@@ -25,6 +25,8 @@ struct _Packet;
 struct _PacketsPerType;
 struct _SockReceive;
 
+#pragma region stats
+
 struct _ConnectionStats {
 
 	time_t connection_threshold_time;       // every time we want to reset the connection's stats
@@ -40,6 +42,10 @@ struct _ConnectionStats {
 };
 
 typedef struct _ConnectionStats ConnectionStats;
+
+#pragma endregion
+
+#pragma region main
 
 struct _Connection {
 
@@ -153,6 +159,8 @@ CLIENT_PUBLIC void connection_remove_auth_data (Connection *connection);
 // returns 0 on success, 1 on error
 CLIENT_PUBLIC u8 connection_generate_auth_packet (Connection *connection);
 
+#pragma region start
+
 // creates a new connection that is ready to be started
 // returns a newly allocated connection on success, NULL if any initial setup has failed
 CLIENT_PUBLIC Connection *connection_create (const char *ip_address, u16 port, Protocol protocol, bool use_ipv6);
@@ -160,6 +168,10 @@ CLIENT_PUBLIC Connection *connection_create (const char *ip_address, u16 port, P
 // starts a connection -> connects to the specified ip and port
 // returns 0 on success, 1 on error
 CLIENT_PUBLIC int connection_start (Connection *connection);
+
+#pragma endregion
+
+#pragma region update
 
 typedef struct ConnectionCustomReceiveData {
 
@@ -172,7 +184,13 @@ typedef struct ConnectionCustomReceiveData {
 // starts listening and receiving data in the connection sock
 CLIENT_PUBLIC void connection_update (void *ptr);
 
+#pragma endregion
+
+#pragma region end
+
 // closes a connection directly
 CLIENT_PUBLIC void connection_close (Connection *connection);
+
+#pragma endregion
 
 #endif

--- a/include/client/files.h
+++ b/include/client/files.h
@@ -86,7 +86,9 @@ CLIENT_PUBLIC ssize_t file_send_by_fd (
 // returns 0 on success, 1 on error
 CLIENT_PUBLIC u8 file_receive (
 	struct _Client *client, struct _Connection *connection,
-	FileHeader *file_header, char **saved_filename
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 );
 
 #pragma endregion

--- a/include/client/files.h
+++ b/include/client/files.h
@@ -66,7 +66,7 @@ typedef struct _FileHeader FileHeader;
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CLIENT_PUBLIC ssize_t file_send (
-	Client *client, Connection *connection,
+	struct _Client *client, struct _Connection *connection,
 	const char *filename
 );
 
@@ -74,7 +74,7 @@ CLIENT_PUBLIC ssize_t file_send (
 // first the FileHeader in a regular packet, then the file contents between sockets
 // returns the number of bytes sent, or -1 on error
 CLIENT_PUBLIC ssize_t file_send_by_fd (
-	Client *client, Connection *connection,
+	struct _Client *client, struct _Connection *connection,
 	int file_fd, const char *actual_filename, size_t filelen
 );
 

--- a/include/client/handler.h
+++ b/include/client/handler.h
@@ -31,7 +31,17 @@ CLIENT_PRIVATE SockReceive *sock_receive_new (void);
 
 CLIENT_PRIVATE void sock_receive_delete (void *sock_receive_ptr);
 
-// receives incoming data from the socket
-CLIENT_PUBLIC void client_receive (struct _Client *client, struct _Connection *connection);
+// receive data from connection's socket
+// this method does not perform any checks and expects a valid buffer
+// to handle incomming data
+// returns 0 on success, 1 on error
+CLIENT_PRIVATE unsigned int client_receive_internal (
+	struct _Client *client, struct _Connection *connection,
+	char *buffer, const size_t buffer_size
+);
+
+// allocates a new packet buffer to receive incoming data from the connection's socket
+// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
+CLIENT_PUBLIC unsigned int client_receive (struct _Client *client, struct _Connection *connection);
 
 #endif

--- a/include/client/timer.h
+++ b/include/client/timer.h
@@ -1,5 +1,5 @@
-#ifndef _CLIENT_TIME_H_
-#define _CLIENT_TIME_H_
+#ifndef _CLIENT_TIMER_H_
+#define _CLIENT_TIMER_H_
 
 #ifndef __USE_POSIX199309
 	#define __USE_POSIX199309

--- a/include/client/utils/log.h
+++ b/include/client/utils/log.h
@@ -35,15 +35,16 @@
 	XX(5, 	TEST, 		[TEST])					\
 	XX(6, 	CERVER, 	[CERVER])				\
 	XX(7, 	CLIENT, 	[CLIENT])				\
-	XX(8, 	HANDLER, 	[HANDLER])				\
-	XX(9, 	ADMIN, 		[ADMIN])				\
-	XX(10, 	EVENT, 		[EVENT])				\
-	XX(11, 	PACKET, 	[PACKET])				\
-	XX(12, 	REQ, 		[REQ])					\
-	XX(13, 	FILE, 		[FILE])					\
-	XX(14, 	HTTP, 		[HTTP])					\
-	XX(15, 	GAME, 		[GAME])					\
-	XX(16, 	PLAYER, 	[PLAYER)				\
+	XX(8, 	CONNECTION, [CONNECTION])			\
+	XX(9, 	HANDLER, 	[HANDLER])				\
+	XX(10, 	ADMIN, 		[ADMIN])				\
+	XX(11, 	EVENT, 		[EVENT])				\
+	XX(12, 	PACKET, 	[PACKET])				\
+	XX(13, 	REQ, 		[REQ])					\
+	XX(14, 	FILE, 		[FILE])					\
+	XX(15, 	HTTP, 		[HTTP])					\
+	XX(16, 	GAME, 		[GAME])					\
+	XX(17, 	PLAYER, 	[PLAYER)				\
 
 typedef enum LogType {
 

--- a/include/client/utils/log.h
+++ b/include/client/utils/log.h
@@ -5,6 +5,13 @@
 
 #include "client/config.h"
 
+#define LOG_POOL_INIT			32
+
+#define LOG_HEADER_SIZE			32
+#define LOG_HEADER_HALF_SIZE	LOG_HEADER_SIZE / 2
+
+#define LOG_MESSAGE_SIZE		4096
+
 #define LOG_COLOR_RED       "\x1b[31m"
 #define LOG_COLOR_GREEN     "\x1b[32m"
 #define LOG_COLOR_YELLOW    "\x1b[33m"
@@ -12,6 +19,8 @@
 #define LOG_COLOR_MAGENTA   "\x1b[35m"
 #define LOG_COLOR_CYAN      "\x1b[36m"
 #define LOG_COLOR_RESET     "\x1b[0m"
+
+#pragma region types
 
 #define LOG_TYPE_MAP(XX)						\
 	XX(0, 	NONE, 		[NONE])					\
@@ -40,6 +49,15 @@ typedef enum LogType {
 	
 } LogType;
 
+#pragma endregion
+
+#pragma region public
+
+CLIENT_PUBLIC void client_log (
+	LogType first_type, LogType second_type,
+	const char *format, ...
+);
+
 CLIENT_PUBLIC void client_log_msg (
 	FILE *__restrict __stream, 
 	LogType first_type, LogType second_type,
@@ -47,15 +65,17 @@ CLIENT_PUBLIC void client_log_msg (
 );
 
 // prints a red error message to stderr
-CLIENT_PUBLIC void client_log_error (const char *msg);
+CLIENT_PUBLIC void client_log_error (const char *msg, ...);
 
 // prints a yellow warning message to stderr
-CLIENT_PUBLIC void client_log_warning (const char *msg);
+CLIENT_PUBLIC void client_log_warning (const char *msg, ...);
 
 // prints a green success message to stdout
-CLIENT_PUBLIC void client_log_success (const char *msg);
+CLIENT_PUBLIC void client_log_success (const char *msg, ...);
 
 // prints a debug message to stdout
-CLIENT_PUBLIC void client_log_debug (const char *msg);
+CLIENT_PUBLIC void client_log_debug (const char *msg, ...);
+
+#pragma endregion
 
 #endif

--- a/include/client/utils/log.h
+++ b/include/client/utils/log.h
@@ -78,4 +78,12 @@ CLIENT_PUBLIC void client_log_debug (const char *msg, ...);
 
 #pragma endregion
 
+#pragma region main
+
+CLIENT_PRIVATE void client_log_init (void);
+
+CLIENT_PRIVATE void client_log_end (void);
+
+#pragma endregion
+
 #endif

--- a/include/client/utils/log.h
+++ b/include/client/utils/log.h
@@ -113,7 +113,7 @@ CLIENT_EXPORT void client_log_set_local_time (bool value);
 
 // creates and prints a message of custom types
 // based on the first type, the message can be printed with colors to stdout
-CLIENT_PUBLIC void cerver_log (
+CLIENT_PUBLIC void client_log (
 	LogType first_type, LogType second_type,
 	const char *format, ...
 );

--- a/include/client/version.h
+++ b/include/client/version.h
@@ -3,10 +3,10 @@
 
 #include "client/config.h"
 
-#define CLIENT_VERSION                      "1.3.2rc-1"
-#define CLIENT_VERSION_NAME                 "Release 1.3.2rc-1"
-#define CLIENT_VERSION_DATE			        "16/10/2020"
-#define CLIENT_VERSION_TIME			        "23:31 CST"
+#define CLIENT_VERSION                      "1.3.2rc-2"
+#define CLIENT_VERSION_NAME                 "Release 1.3.2rc-2"
+#define CLIENT_VERSION_DATE			        "26/10/2020"
+#define CLIENT_VERSION_TIME			        "17:23 CST"
 #define CLIENT_VERSION_AUTHOR			    "Erick Salas"
 
 // print full cerver client version information

--- a/include/client/version.h
+++ b/include/client/version.h
@@ -3,10 +3,10 @@
 
 #include "client/config.h"
 
-#define CLIENT_VERSION                      "1.3.1rc-9"
-#define CLIENT_VERSION_NAME                 "Release 1.3.1rc-9"
-#define CLIENT_VERSION_DATE			        "11/10/2020"
-#define CLIENT_VERSION_TIME			        "23:29 CST"
+#define CLIENT_VERSION                      "1.3.2rc-1"
+#define CLIENT_VERSION_NAME                 "Release 1.3.2rc-1"
+#define CLIENT_VERSION_DATE			        "16/10/2020"
+#define CLIENT_VERSION_TIME			        "23:31 CST"
 #define CLIENT_VERSION_AUTHOR			    "Erick Salas"
 
 // print full cerver client version information

--- a/include/client/version.h
+++ b/include/client/version.h
@@ -3,10 +3,10 @@
 
 #include "client/config.h"
 
-#define CLIENT_VERSION                      "1.3.2rc-2"
-#define CLIENT_VERSION_NAME                 "Release 1.3.2rc-2"
+#define CLIENT_VERSION                      "1.3.2b-1"
+#define CLIENT_VERSION_NAME                 "Beta 1.3.2b-1"
 #define CLIENT_VERSION_DATE			        "26/10/2020"
-#define CLIENT_VERSION_TIME			        "17:23 CST"
+#define CLIENT_VERSION_TIME			        "18:22 CST"
 #define CLIENT_VERSION_AUTHOR			    "Erick Salas"
 
 // print full cerver client version information

--- a/makefile
+++ b/makefile
@@ -6,7 +6,14 @@ MATH		:= -lm
 
 DEFINES		:= -D _GNU_SOURCE
 
-DEVELOPMENT = -g -D CERVER_DEBUG -D CLIENT_DEBUG -D HANDLER_DEBUG -D PACKETS_DEBUG -D AUTH_DEBUG -D FILES_DEBUG
+DEVELOPMENT := -g \
+				-D CERVER_DEBUG 		\
+				-D CLIENT_DEBUG 		\
+				-D CONNECTION_DEBUG 	\
+				-D HANDLER_DEBUG 		\
+				-D PACKETS_DEBUG 		\
+				-D AUTH_DEBUG 			\
+				-D FILES_DEBUG
 
 CC          := gcc
 
@@ -16,6 +23,8 @@ BUILDDIR    := objs
 TARGETDIR   := bin
 
 EXAMDIR		:= examples
+EXABUILD	:= $(EXAMDIR)/objs
+EXATARGET	:= $(EXAMDIR)/bin
 
 SRCEXT      := c
 DEPEXT      := d
@@ -26,10 +35,14 @@ LIB         := $(PTHREAD) $(MATH)
 INC         := -I $(INCDIR) -I /usr/local/include
 INCDEP      := -I $(INCDIR)
 
+EXAFLAGS	:= -g $(DEFINES) -Wall -Wno-unknown-pragmas
+EXALIBS		:= -L ./bin -l client
+
 SOURCES     := $(shell find $(SRCDIR) -type f -name *.$(SRCEXT))
 OBJECTS     := $(patsubst $(SRCDIR)/%,$(BUILDDIR)/%,$(SOURCES:.$(SRCEXT)=.$(OBJEXT)))
 
 EXAMPLES	:= $(shell find $(EXAMDIR) -type f -name *.$(SRCEXT))
+EXOBJS		:= $(patsubst $(EXAMDIR)/%,$(EXABUILD)/%,$(EXAMPLES:.$(SRCEXT)=.$(OBJEXT)))
 
 # all: directories $(TARGET)
 all: directories $(SLIB)
@@ -52,7 +65,8 @@ directories:
 clean:
 	@$(RM) -rf $(BUILDDIR)
 	@$(RM) -rf $(TARGETDIR)
-	@$(RM) -rf ./examples/bin
+	@$(RM) -rf $(EXABUILD)
+	@$(RM) -rf $(EXATARGET)
 
 # pull in dependency info for *existing* .o files
 -include $(OBJECTS:.$(OBJEXT)=.$(DEPEXT))
@@ -64,7 +78,7 @@ clean:
 $(SLIB): $(OBJECTS)
 	$(CC) $^ $(LIB) -shared -o $(TARGETDIR)/$(SLIB)
 
-# compile
+# compile sources
 $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@mkdir -p $(dir $@)
 	$(CC) $(CFLAGS) $(INC) $(LIB) -c -o $@ $<
@@ -74,17 +88,28 @@ $(BUILDDIR)/%.$(OBJEXT): $(SRCDIR)/%.$(SRCEXT)
 	@sed -e 's/.*://' -e 's/\\$$//' < $(BUILDDIR)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(BUILDDIR)/$*.$(DEPEXT)
 	@rm -f $(BUILDDIR)/$*.$(DEPEXT).tmp
 
-examples: $(EXAMPLES)
+examples: $(EXOBJS)
 	@mkdir -p ./examples/bin
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/test.c -o ./examples/bin/test -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/handlers.c -o ./examples/bin/handlers -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/multi.c -o ./examples/bin/multi -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/packets.c -o ./examples/bin/packets -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/requests.c -o ./examples/bin/requests -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/files.c -o ./examples/bin/files -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/auth.c -o ./examples/bin/auth -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/sessions.c -o ./examples/bin/sessions -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/admin.c -o ./examples/bin/admin -l client
-	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/logs.c -o ./examples/bin/logs -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/test.o -o ./$(EXATARGET)/test -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/handlers.o -o ./$(EXATARGET)/handlers -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/multi.o -o ./$(EXATARGET)/multi -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/packets.o -o ./$(EXATARGET)/packets -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/requests.o -o ./$(EXATARGET)/requests -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/files.o -o ./$(EXATARGET)/files -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/auth.o -o ./$(EXATARGET)/auth -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/sessions.o -o ./$(EXATARGET)/sessions -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/admin.o -o ./$(EXATARGET)/admin -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/balancer.o -o ./$(EXATARGET)/balancer -l client
+	$(CC) -I ./$(INCDIR) -L ./$(TARGETDIR) ./$(EXABUILD)/logs.o -o ./$(EXATARGET)/logs -l client
+
+# compile examples
+$(EXABUILD)/%.$(OBJEXT): $(EXAMDIR)/%.$(SRCEXT)
+	@mkdir -p $(dir $@)
+	$(CC) $(EXAFLAGS) $(INC) $(EXALIBS) -c -o $@ $<
+	@$(CC) $(EXAFLAGS) $(INCDEP) -MM $(EXAMDIR)/$*.$(SRCEXT) > $(EXABUILD)/$*.$(DEPEXT)
+	@cp -f $(EXABUILD)/$*.$(DEPEXT) $(EXABUILD)/$*.$(DEPEXT).tmp
+	@sed -e 's|.*:|$(EXABUILD)/$*.$(OBJEXT):|' < $(EXABUILD)/$*.$(DEPEXT).tmp > $(EXABUILD)/$*.$(DEPEXT)
+	@sed -e 's/.*://' -e 's/\\$$//' < $(EXABUILD)/$*.$(DEPEXT).tmp | fmt -1 | sed -e 's/^ *//' -e 's/$$/:/' >> $(EXABUILD)/$*.$(DEPEXT)
+	@rm -f $(EXABUILD)/$*.$(DEPEXT).tmp
 
 .PHONY: all clean examples

--- a/makefile
+++ b/makefile
@@ -85,5 +85,6 @@ examples: $(EXAMPLES)
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/auth.c -o ./examples/bin/auth -l client
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/sessions.c -o ./examples/bin/sessions -l client
 	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/admin.c -o ./examples/bin/admin -l client
+	$(CC) -g -Wall -Wno-unknown-pragmas -I ./include -L ./bin ./examples/logs.c -o ./examples/bin/logs -l client
 
 .PHONY: all clean examples

--- a/src/client/cerver.c
+++ b/src/client/cerver.c
@@ -100,18 +100,19 @@ void cerver_stats_print (Cerver *cerver) {
 		}
 
 		else {
-			char *status = c_string_create ("Cerver %s does not have a reference to cerver stats!",
-				cerver->name->str);
-			if (status) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_CERVER, status);
-				free (status);
-			}
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_CERVER,
+				"Cerver %s does not have a reference to cerver stats!",
+				cerver->name->str
+			);
 		}
 	}
 
 	else {
-		client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CERVER,
-			"Cant print stats of a NULL cerver!");
+		client_log (
+			LOG_TYPE_WARNING, LOG_TYPE_CERVER,
+			"Cant print stats of a NULL cerver!"
+		);
 	}
 
 }
@@ -156,30 +157,26 @@ static void cerver_check_info_handle_auth (Cerver *cerver, Client *client, Conne
 	if (cerver && connection) {
 		if (cerver->auth_required) {
 			// #ifdef CLIENT_DEBUG
-			client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver requires authentication.");
+			client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver requires authentication.");
 			// #endif
 			if (connection->auth_data) {
 				#ifdef CLIENT_DEBUG
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Sending auth data to cerver...");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Sending auth data to cerver...");
 				#endif
 
 				if (!connection->auth_packet) {
 					if (!connection_generate_auth_packet (connection)) {
-						char *status = c_string_create ("cerver_check_info () - Generated connection %s auth packet!",
-							connection->name->str);
-						if (status) {
-							client_log_success (status);
-							free (status);
-						}
+						client_log_success (
+							"cerver_check_info () - Generated connection %s auth packet!",
+							connection->name->str
+						);
 					}
 
 					else {
-						char *status = c_string_create ("cerver_check_info () - Failed to generate connection %s auth packet!",
-							connection->name->str);
-						if (status) {
-							client_log_error (status);
-							free (status);
-						}
+						client_log_error (
+							"cerver_check_info () - Failed to generate connection %s auth packet!",
+							connection->name->str
+						);
 					}
 				}
 
@@ -187,44 +184,38 @@ static void cerver_check_info_handle_auth (Cerver *cerver, Client *client, Conne
 					packet_set_network_values (connection->auth_packet, NULL, connection);
 
 					if (!packet_send (connection->auth_packet, 0, NULL, false)) {
-						char *s = c_string_create ("cerver_check_info () - Sent connection %s auth packet!",
-							connection->name->str);
-						if (s) {
-							client_log_success (s);
-							free (s);
-						}
+						client_log_success (
+							"cerver_check_info () - Sent connection %s auth packet!",
+							connection->name->str
+						);
 
 						client_event_trigger (CLIENT_EVENT_AUTH_SENT, client, connection);
 					}
 
 					else {
-						char *s = c_string_create ("cerver_check_info () - Failed to send connection %s auth packet!",
-							connection->name->str);
-						if (s) {
-							client_log_error (s);
-							free (s);
-						}
+						client_log_error (
+							"cerver_check_info () - Failed to send connection %s auth packet!",
+							connection->name->str
+						);
 					}
 				}
 
 				if (cerver->uses_sessions) {
-					client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver supports sessions.");
+					client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver supports sessions.");
 				}
 			}
 
 			else {
-				char *s = c_string_create ("Connection %s does NOT have an auth packet!",
-					connection->name->str);
-				if (s) {
-					client_log_error (s);
-					free (s);
-				}
+				client_log_error (
+					"Connection %s does NOT have an auth packet!",
+					connection->name->str
+				);
 			}
 		}
 
 		else {
 			#ifdef CLIENT_DEBUG
-			client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver does NOT require authentication.");
+			client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver does NOT require authentication.");
 			#endif
 		}
 	}
@@ -241,11 +232,10 @@ static u8 cerver_check_info (Cerver *cerver, Client *client, Connection *connect
 		connection->cerver = cerver;
 
 		#ifdef CLIENT_DEBUG
-		char *s = c_string_create ("Connected to cerver %s.", cerver->name->str);
-		if (s) {
-			client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, s);
-			free (s);
-		}
+		client_log (
+			LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+			"Connected to cerver %s.", cerver->name->str
+		);
 
 		if (cerver->welcome) {
 			printf ("%s\n", cerver->welcome->str);
@@ -253,46 +243,46 @@ static u8 cerver_check_info (Cerver *cerver, Client *client, Connection *connect
 
 		switch (cerver->protocol) {
 			case PROTOCOL_TCP:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using TCP protocol.");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using TCP protocol.");
 				break;
 			case PROTOCOL_UDP:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using UDP protocol.");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver using UDP protocol.");
 				break;
 
 			default:
-				client_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Cerver using unknown protocol.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Cerver using unknown protocol.");
 				break;
 		}
 		#endif
 
 		if (cerver->use_ipv6) {
 			#ifdef CLIENT_DEBUG
-			client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
+			client_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
 			#endif
 		}
 
 		#ifdef CLIENT_DEBUG
 		switch (cerver->type) {
 			case CERVER_TYPE_CUSTOM:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
+				client_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
 				break;
 
 			case CERVER_TYPE_GAME:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: GAME");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: GAME");
 				break;
 			case CERVER_TYPE_WEB:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: WEB");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: WEB");
 				break;
 			case CERVER_TYPE_FILES:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: FILE");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: FILES");
 				break;
 
 			case CERVER_TYPE_BALANCER:
-				client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: BALANCER");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: BALANCER");
 				break;
 
 			default:
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Cerver type: UNKNOWN");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Cerver type: UNKNOWN");
 				break;
 		}
 		#endif
@@ -316,11 +306,11 @@ static void cerver_packet_handle_info (Packet *packet) {
 		char *end = (char *) packet->data;
 
 		#ifdef CLIENT_DEBUG
-		client_log_msg (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Received a cerver info packet.");
+		client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Received a cerver info packet.");
 		#endif
 		Cerver *cerver = cerver_deserialize ((SCerver *) end);
 		if (cerver_check_info (cerver, packet->client, packet->connection))
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to correctly check cerver info!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to correctly check cerver info!");
 	}
 
 }
@@ -332,19 +322,19 @@ void cerver_packet_handler (Packet *packet) {
 		switch (packet->header->request_type) {
 			case CERVER_PACKET_TYPE_INFO:
 				cerver_packet_handle_info (packet);
-			break;
+				break;
 
 			// the cerves is going to be teardown, we have to disconnect
 			case CERVER_PACKET_TYPE_TEARDOWN:
 				#ifdef CLIENT_DEBUG
-				client_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_NONE, "---> Server teardown! <---");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "---> Server teardown! <---");
 				#endif
 				client_got_disconnected (packet->client);
 				client_event_trigger (CLIENT_EVENT_DISCONNECTED, packet->client, NULL);
 				break;
 
 			default:
-				client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown cerver type packet.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_NONE, "Unknown cerver type packet.");
 				break;
 		}
 	}

--- a/src/client/cerver.c
+++ b/src/client/cerver.c
@@ -257,14 +257,14 @@ static u8 cerver_check_info (Cerver *cerver, Client *client, Connection *connect
 
 		if (cerver->use_ipv6) {
 			#ifdef CLIENT_DEBUG
-			client_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
+			client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver is configured to use ipv6");
 			#endif
 		}
 
 		#ifdef CLIENT_DEBUG
 		switch (cerver->type) {
 			case CERVER_TYPE_CUSTOM:
-				client_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
+				client_log (LOG_TYPE_DEBUG, LOG_TYPE_NONE, "Cerver type: CUSTOM");
 				break;
 
 			case CERVER_TYPE_GAME:

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -29,6 +29,26 @@ int client_disconnect (Client *client);
 int client_connection_end (Client *client, Connection *connection);
 Connection *client_connection_get_by_socket (Client *client, i32 sock_fd);
 
+#pragma region global
+
+// initializes global client values
+// should be called only once at the start of the program
+void client_init (void) {
+
+	client_log_init ();
+
+}
+
+// correctly disposes global values
+// should be called only once at the very end of the program
+void client_end (void) {
+
+	client_log_end ();
+
+}
+
+#pragma endregion
+
 #pragma region stats
 
 static ClientStats *client_stats_new (void) {

--- a/src/client/client.c
+++ b/src/client/client.c
@@ -98,8 +98,7 @@ void client_stats_print (Client *client) {
 		}
 
 		else {
-			client_log_msg (
-				stderr, 
+			client_log (
 				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
 				"Client does not have a reference to a client stats!"
 			);
@@ -107,8 +106,7 @@ void client_stats_print (Client *client) {
 	}
 
 	else {
-		client_log_msg (
-			stderr,
+		client_log (
 			LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
 			"Can't get stats of a NULL client!"
 		);
@@ -397,12 +395,14 @@ Connection *client_connection_create (
 				dlist_insert_after (client->connections, dlist_end (client->connections), connection);
 			}
 
-			else client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create new connection!");
+			else client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create new connection!");
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE,
-				"Failed to create new connection, no ip provided!");
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_NONE,
+				"Failed to create new connection, no ip provided!"
+			);
 		}
 	}
 
@@ -575,22 +575,18 @@ int client_connection_start (Client *client, Connection *connection) {
 				}
 
 				else {
-					char *s = c_string_create ("client_connection_start () - Failed to create update thread for client %s",
-						client->name->str);
-					if (s) {
-						client_log_error (s);
-						free (s);
-					}
+					client_log_error (
+						"client_connection_start () - Failed to create update thread for client %s",
+						client->name->str
+					);
 				}
 			}
 
 			else {
-				char *s = c_string_create ("client_connection_start () - Failed to start client %s",
-					client->name->str);
-				if (s) {
-					client_log_error (s);
-					free (s);
-				}
+				client_log_error (
+					"client_connection_start () - Failed to start client %s",
+					client->name->str
+				);
 			}
 		}
 	}
@@ -615,12 +611,10 @@ int client_connect_and_start (Client *client, Connection *connection) {
 		}
 
 		else {
-			char *s = c_string_create ("client_connect_and_start () - Client %s failed to connect",
-				client->name->str);
-			if (s) {
-				client_log_error (s);
-				free (s);
-			}
+			client_log_error (
+				"client_connect_and_start () - Client %s failed to connect",
+				client->name->str
+			);
 		}
 	}
 
@@ -907,11 +901,10 @@ u8 client_file_send (Client *client, Connection *connection, const char *filenam
 			}
 
 			else {
-				char *s = c_string_create ("client_file_send () - Failed to open file %s", filename);
-				if (s) {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-					free (s);
-				}
+				client_log (
+					LOG_TYPE_ERROR, LOG_TYPE_FILE,
+					"client_file_send () - Failed to open file %s", filename
+				);
 			}
 		}
 

--- a/src/client/collections/pool.c
+++ b/src/client/collections/pool.c
@@ -10,7 +10,11 @@ static Pool *pool_new (void) {
 	Pool *pool = (Pool *) malloc (sizeof (Pool));
 	if (pool) {
 		pool->dlist = NULL;
+
 		pool->destroy = NULL;
+		pool->create = NULL;
+
+		pool->produce = false;
 	}
 
 	return pool;
@@ -19,16 +23,32 @@ static Pool *pool_new (void) {
 
 #pragma endregion
 
+// sets a destroy method to be used by the pool to correctly dispose data
+void pool_set_destroy (Pool *pool, void (*destroy)(void *data)) {
+
+	if (pool) pool->destroy = destroy;
+
+}
+
+// sets a create method to be used by the pool to correctly allocate new data
+void pool_set_create (Pool *pool, void *(*create)(void)) {
+
+	if (pool) pool->create = create;
+
+}
+
+// sets the pool's ability to produce a element when a pop request is done and the pool is empty
+// the pool will use its create method to allocate a new element and fullfil the request
+void pool_set_produce_if_empty (Pool *pool, bool produce) {
+
+	if (pool) pool->produce = produce;
+
+}
+
 // returns how many elements are inside the pool
 size_t pool_size (Pool *pool) {
 
-	size_t retval = 0;
-
-	if (pool) {
-		retval = dlist_size (pool->dlist);
-	}
-
-	return retval;
+	return pool ? dlist_size (pool->dlist) : 0;
 
 }
 
@@ -44,57 +64,39 @@ Pool *pool_create (void (*destroy)(void *data)) {
 
 }
 
-// uses the create method to populate the pool with n elements
+// uses the create method to populate the pool with n elements (NULL to use pool's set method)
 // returns 0 on no error, 1 if at least one element failed to be inserted
-int pool_init (Pool *pool,
-	void *(*create)(void), unsigned int n_elements) {
+int pool_init (
+	Pool *pool,
+	void *(*create)(void), unsigned int n_elements
+) {
 
-	int errors = 0;
-
-	for (unsigned int i = 0; i < n_elements; i++) {
-		errors |= dlist_insert_after (
-			pool->dlist,
-			dlist_end (pool->dlist),
-			create ()
-		);
-	}
-
-	return errors;
-
-}
-
-void pool_delete (Pool *pool) {
+	int retval = 1;
 
 	if (pool) {
-		dlist_delete (pool->dlist);
+		void *(*produce)(void) = create ? create : pool->create;
+		if (produce) {
+			int errors = 0;
 
-		free (pool);
+			for (unsigned int i = 0; i < n_elements; i++) {
+				errors |= dlist_insert_after (
+					pool->dlist,
+					dlist_end (pool->dlist),
+					produce ()
+				);
+			}
+
+			retval = errors;
+		}
 	}
+
+	return retval;
 
 }
 
-// destroys all of the dlist's elements and their data but keeps the dlist
-void pool_reset (Pool *pool) {
+int pool_push (Pool *pool, void *data) {
 
-	if (pool) {
-		dlist_reset (pool->dlist);
-	}
-
-}
-
-// only gets rid of the list elements, but the data is kept
-// this is usefull if another dlist or structure points to the same data
-void pool_clear (Pool *pool) {
-
-	if (pool) {
-		dlist_clear (pool->dlist);
-	}
-
-}
-
-unsigned int pool_push (Pool *pool, void *data) {
-
-	unsigned int retval = 1;
+	int retval = 1;
 
 	if (pool && data) {
 		retval = dlist_insert_after (
@@ -117,8 +119,42 @@ void *pool_pop (Pool *pool) {
 			pool->dlist,
 			NULL
 		);
+
+		if (!retval && pool->produce) {
+			retval = pool->create ();
+		}
 	}
 
 	return retval;
+
+}
+
+// only gets rid of the list elements, but the data is kept
+// this is usefull if another structure points to the same data
+void pool_clear (Pool *pool) {
+
+	if (pool) {
+		dlist_clear (pool->dlist);
+	}
+
+}
+
+// destroys all of the dlist's elements and their data but keeps the pool
+void pool_reset (Pool *pool) {
+
+	if (pool) {
+		dlist_reset (pool->dlist);
+	}
+
+}
+
+// deletes the pool and all of its members using the destroy method
+void pool_delete (Pool *pool) {
+
+	if (pool) {
+		dlist_delete (pool->dlist);
+
+		free (pool);
+	}
 
 }

--- a/src/client/connection.c
+++ b/src/client/connection.c
@@ -60,6 +60,8 @@ static ConnectionStats *connection_stats_create (void) {
 
 #pragma endregion
 
+#pragma region main
+
 Connection *connection_new (void) {
 
 	Connection *connection = (Connection *) malloc (sizeof (Connection));
@@ -313,6 +315,10 @@ u8 connection_generate_auth_packet (Connection *connection) {
 
 }
 
+#pragma endregion
+
+#pragma region start
+
 // sets up the new connection values
 static u8 connection_init (Connection *connection) {
 
@@ -415,6 +421,10 @@ int connection_start (Connection *connection) {
 
 }
 
+#pragma endregion
+
+#pragma region update
+
 static ConnectionCustomReceiveData *connection_custom_receive_data_new (Client *client, Connection *connection, void *args) {
 
 	ConnectionCustomReceiveData *custom_data = (ConnectionCustomReceiveData *) malloc (sizeof (ConnectionCustomReceiveData));
@@ -475,6 +485,10 @@ void connection_update (void *ptr) {
 
 }
 
+#pragma endregion
+
+#pragma region end
+
 // closes a connection directly
 void connection_close (Connection *connection) {
 
@@ -487,3 +501,5 @@ void connection_close (Connection *connection) {
 	}
 
 }
+
+#pragma endregion

--- a/src/client/connection.c
+++ b/src/client/connection.c
@@ -328,7 +328,7 @@ static u8 connection_init (Connection *connection) {
 				break;
 
 			default:
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Unkonw protocol type!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Unkonw protocol type!");
 				return 1;
 		}
 
@@ -351,7 +351,7 @@ static u8 connection_init (Connection *connection) {
 		}
 
 		else {
-			client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create new socket!");
+			client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create new socket!");
 		}
 	}
 
@@ -379,7 +379,7 @@ Connection *connection_create (const char *ip_address, u16 port, Protocol protoc
 			// set up the new connection to be ready to be started
 			if (connection_init (connection)) {
 				#ifdef CLIENT_DEBUG
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to init the new connection!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to init the new connection!");
 				#endif
 				connection_delete (connection);
 				connection = NULL;

--- a/src/client/errors.c
+++ b/src/client/errors.c
@@ -268,11 +268,7 @@ void client_error_packet_handler (Packet *packet) {
 					s_error->msg
 				)) {
 					// not error action is registered to handle the error
-					char *status = c_string_create ("Failed to authenticate - %s", s_error->msg);
-					if (status) {
-						client_log_error (status);
-						free (status);
-					}
+					client_log_error ("Failed to authenticate - %s", s_error->msg);
 				}
 			} break;
 

--- a/src/client/files.c
+++ b/src/client/files.c
@@ -381,7 +381,7 @@ static int file_send_open (
 
 	int file_fd = -1;
 
-	char *last = strrchr (filename, '/');
+	char *last = strrchr ((char *) filename, '/');
 	*actual_filename = last ? last + 1 : NULL;
 	if (actual_filename) {
 		// try to open the file
@@ -556,7 +556,7 @@ static u8 file_receive_internal (Connection *connection, size_t filelen, int fil
 
 	u8 retval = 1;
 
-	int buff_size = 4096;
+	size_t buff_size = 4096;
 	int pipefds[2] = { 0 };
 	ssize_t received = 0;
 	ssize_t moved = 0;

--- a/src/client/files.c
+++ b/src/client/files.c
@@ -46,19 +46,11 @@ unsigned int files_create_dir (const char *dir_path, mode_t mode) {
 				}
 
 				else {
-					char *s = c_string_create ("Failed to create dir %s!", dir_path);
-					if (s) {
-						client_log_error (s);
-						free (s);
-					}
+					client_log_error ("Failed to create dir %s!", dir_path);
 				}
 			} break;
 			case 0: {
-				char *s = c_string_create ("Dir %s already exists!", dir_path);
-				if (s) {
-					client_log_warning (s);
-					free (s);
-				}
+				client_log_warning ("Dir %s already exists!", dir_path);
 			} break;
 
 			default: break;
@@ -124,11 +116,7 @@ DoubleList *files_get_from_dir (const char *dir) {
 		}
 
 		else {
-			char *status = c_string_create ("Failed to open dir %s", dir);
-			if (status) {
-				client_log_error (status);
-				free (status);
-			}
+			client_log_error ("Failed to open dir %s", dir);
 		}
 	}
 
@@ -175,11 +163,7 @@ DoubleList *file_get_lines (const char *filename) {
 		}
 
 		else {
-			char *status = c_string_create ("Failed to open file: %s", filename);
-			if (status) {
-				client_log_error (status);
-				free (status);
-			}
+			client_log_error ("Failed to open file: %s", filename);
 		}
 	}
 
@@ -215,11 +199,10 @@ FILE *file_open_as_file (const char *filename, const char *modes, struct stat *f
 
 		else {
 			#ifdef FILES_DEBUG
-			char *s = c_string_create ("File %s not found!", filename);
-			if (s) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-				free (s);
-			}
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"File %s not found!", filename
+			);
 			#endif
 		}
 	}
@@ -244,11 +227,10 @@ char *file_read (const char *filename, size_t *file_size) {
 			// read the entire file into the buffer
 			if (fread (file_contents, filestatus.st_size, 1, fp) != 1) {
 				#ifdef FILES_DEBUG
-				char *s = c_string_create ("Failed to read file (%s) contents!");
-				if (s) {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-					free (s);
-				}
+				client_log (
+					LOG_TYPE_ERROR, LOG_TYPE_FILE,
+					"Failed to read file (%s) contents!", filename
+				);
 				#endif
 
 				free (file_contents);
@@ -259,11 +241,10 @@ char *file_read (const char *filename, size_t *file_size) {
 
 		else {
 			#ifdef FILES_DEBUG
-			char *s = c_string_create ("Unable to open file %s.", filename);
-			if (s) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-				free (s);
-			}
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"Unable to open file %s.", filename
+			);
 			#endif
 		}
 	}
@@ -285,11 +266,10 @@ int file_open_as_fd (const char *filename, struct stat *filestatus, int flags) {
 
 		else {
 			#ifdef FILES_DEBUG
-			char *s = c_string_create ("File %s not found!", filename);
-			if (s) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-				free (s);
-			}
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"File %s not found!", filename
+			);
 			#endif
 		}
 	}
@@ -361,8 +341,7 @@ static ssize_t file_send_actual (
 	}
 
 	else {
-		client_log_msg (
-			stderr, 
+		client_log (
 			LOG_TYPE_ERROR, LOG_TYPE_FILE, 
 			"file_send_actual () - failed to send file header"
 		);
@@ -387,11 +366,10 @@ static int file_send_open (
 		// try to open the file
 		file_fd = file_open_as_fd (filename, filestatus, O_RDONLY);
 		if (file_fd <= 0) {
-			char *s = c_string_create ("file_send () - Failed to open file %s", filename);
-			if (s) {
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_FILE, s);
-				free (s);
-			}
+			client_log (
+				LOG_TYPE_ERROR, LOG_TYPE_FILE,
+				"file_send () - Failed to open file %s", filename
+			);
 		}
 	}
 
@@ -486,14 +464,9 @@ static inline u8 file_receive_internal_receive (
 
 		default: {
 			#ifdef FILES_DEBUG
-			char *status = c_string_create (
+			client_log_debug (
 				"file_receive_internal_receive () - spliced %ld bytes", *received
 			);
-
-			if (status) {
-				client_log_debug (status);
-				free (status);
-			}
 			#endif
 
 			retval = 0;
@@ -534,14 +507,7 @@ static inline u8 file_receive_internal_move (
 
 		default: {
 			#ifdef FILES_DEBUG
-			char *status = c_string_create (
-				"file_receive_internal_move () - spliced %ld bytes", *moved
-			);
-
-			if (status) {
-				client_log_debug (status);
-				free (status);
-			}
+			client_log_debug ("file_receive_internal_move () - spliced %ld bytes", *moved);
 			#endif
 
 			retval = 0;

--- a/src/client/files.c
+++ b/src/client/files.c
@@ -586,16 +586,19 @@ static u8 file_receive_internal (Connection *connection, size_t filelen, int fil
 // returns 0 on success, 1 on error
 u8 file_receive (
 	Client *client, Connection *connection,
-	FileHeader *file_header, char **saved_filename
+	FileHeader *file_header,
+	const char *file_data, size_t file_data_len,
+	char **saved_filename
 ) {
 
 	u8 retval = 1;
 
 	// generate a custom filename taking into account the uploads path
 	*saved_filename = c_string_create (
-		"%s/%ld-%s", 
+		"%s/%ld-%d-%s", 
 		client->uploads_path->str, 
-		time (NULL), file_header->filename
+		time (NULL), random_int_in_range (0, 1000),
+		file_header->filename
 	);
 
 	if (*saved_filename) {
@@ -608,21 +611,52 @@ u8 file_receive (
 			// 	SPLICE_F_MOVE | SPLICE_F_MORE
 			// );
 
-			if (!file_receive_internal (
-				connection,
-				file_header->len,
-				file_fd
-			)) {
-				#ifdef FILES_DEBUG
-				client_log_success ("file_receive_internal () has finished");
-				#endif
+			// we received some part of the file when reading packets,
+			// they should be the first ones to be saved into the file
+			if (file_data && file_data_len) {
+				ssize_t wrote = write (file_fd, file_data, file_data_len);
+				if (wrote < 0) {
+					client_log_error ("file_receive_actual () - write () has failed!");
+					perror ("Error");
+					printf ("\n");
+				}
 
-				retval = 0;
+				else {
+					#ifdef FILES_DEBUG
+					printf (
+						"\n\nwrote %ld of file_data_len %ld\n\n",
+						wrote,
+						file_data_len
+					);
+					#endif
+				}
 			}
 
-			else {
-				free (*saved_filename);
-				*saved_filename = NULL;
+			// there is still more data to be received
+			if (file_data_len < file_header->len) {
+				size_t real_filelen = file_header->len - file_data_len;
+				#ifdef FILES_DEBUG
+				printf (
+					"\nfilelen: %ld - file data len %ld = %ld\n\n", 
+					file_header->len, file_data_len, real_filelen
+				);
+				#endif
+				if (!file_receive_internal (
+					connection,
+					real_filelen,
+					file_fd
+				)) {
+					#ifdef FILES_DEBUG
+					client_log_success ("file_receive_internal () has finished");
+					#endif
+
+					retval = 0;
+				}
+
+				else {
+					free (*saved_filename);
+					*saved_filename = NULL;
+				}
 			}
 
 			close (file_fd);

--- a/src/client/game.c
+++ b/src/client/game.c
@@ -110,8 +110,10 @@ static void client_game_lobby_create (Packet *packet) {
 
         else {
             // TODO: trigger error, bad packet
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, 
-                "client_game_lobby_create () - packets to small to get a lobby!");
+            client_log (
+                LOG_TYPE_ERROR, LOG_TYPE_NONE, 
+                "client_game_lobby_create () - packets to small to get a lobby!"
+            );
         }
     }
 
@@ -136,8 +138,10 @@ static void client_game_lobby_join (Packet *packet) {
 
         else {
             // TODO: trigger error, bad packet
-            client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, 
-                "client_game_lobby_join () - packets to small to get a lobby!");
+            client_log (
+                LOG_TYPE_ERROR, LOG_TYPE_NONE, 
+                "client_game_lobby_join () - packets to small to get a lobby!"
+            );
         }
     }
 
@@ -181,8 +185,10 @@ void client_game_packet_handler (Packet *packet) {
             case GAME_PACKET_TYPE_LOBBY_DESTROY: break;
 
             default:
-                client_log_msg (stderr, LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-                    "Got a game packet of unknown type!");
+                client_log (
+                    LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+                    "Got a game packet of unknown type!"
+                );
                 break;
         }
     }

--- a/src/client/handler.c
+++ b/src/client/handler.c
@@ -531,180 +531,178 @@ static void client_receive_handle_buffer (
 	char *buffer, size_t buffer_size
 ) {
 
-	if (buffer && (buffer_size > 0)) {
-		char *end = buffer;
-		size_t buffer_pos = 0;
+	char *end = buffer;
+	size_t buffer_pos = 0;
 
-		SockReceive *sock_receive = connection->sock_receive;
+	SockReceive *sock_receive = connection->sock_receive;
 
-		client_receive_handle_spare_packet (
-			client, connection,
-			buffer_size, &end,
-			&buffer_pos
-		);
+	client_receive_handle_spare_packet (
+		client, connection,
+		buffer_size, &end,
+		&buffer_pos
+	);
 
-		PacketHeader *header = NULL;
-		size_t packet_size = 0;
-		// char *packet_data = NULL;
+	PacketHeader *header = NULL;
+	size_t packet_size = 0;
+	// char *packet_data = NULL;
 
-		size_t remaining_buffer_size = 0;
-		size_t packet_real_size = 0;
-		size_t to_copy_size = 0;
+	size_t remaining_buffer_size = 0;
+	size_t packet_real_size = 0;
+	size_t to_copy_size = 0;
 
-		bool spare_header = false;
+	bool spare_header = false;
 
-		while (buffer_pos < buffer_size) {
-			// printf ("buffer size: %ld\n", buffer_size);
-			remaining_buffer_size = buffer_size - buffer_pos;
-			// printf ("remaining_buffer_size: %ld\n", remaining_buffer_size);
-			// printf ("header size: %ld\n", sizeof (PacketHeader));
+	while (buffer_pos < buffer_size) {
+		// printf ("buffer size: %ld\n", buffer_size);
+		remaining_buffer_size = buffer_size - buffer_pos;
+		// printf ("remaining_buffer_size: %ld\n", remaining_buffer_size);
+		// printf ("header size: %ld\n", sizeof (PacketHeader));
 
-			if (sock_receive->complete_header) {
-				// printf ("\nsock_receive->complete_header\n");
-				packet_header_copy (&header, (PacketHeader *) sock_receive->header);
-				// header = ((PacketHeader *) sock_receive->header);
-				// packet_header_print (header);
+		if (sock_receive->complete_header) {
+			// printf ("\nsock_receive->complete_header\n");
+			packet_header_copy (&header, (PacketHeader *) sock_receive->header);
+			// header = ((PacketHeader *) sock_receive->header);
+			// packet_header_print (header);
 
-				end += sock_receive->remaining_header;
-				buffer_pos += sock_receive->remaining_header;
-				// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
+			end += sock_receive->remaining_header;
+			buffer_pos += sock_receive->remaining_header;
+			// printf ("buffer pos after copy to header: %ld\n", buffer_pos);
 
-				// reset sock header values
-				free (sock_receive->header);
-				sock_receive->header = NULL;
-				sock_receive->header_end = NULL;
-				// sock_receive->curr_header_pos = 0;
-				// sock_receive->remaining_header = 0;
-				sock_receive->complete_header = false;
+			// reset sock header values
+			free (sock_receive->header);
+			sock_receive->header = NULL;
+			sock_receive->header_end = NULL;
+			// sock_receive->curr_header_pos = 0;
+			// sock_receive->remaining_header = 0;
+			sock_receive->complete_header = false;
 
-				spare_header = true;
-			}
+			spare_header = true;
+		}
 
-			else if (remaining_buffer_size >= sizeof (PacketHeader)) {
-				// printf ("\nremaining_buffer_size >= sizeof (PacketHeader)\n");
-				header = (PacketHeader *) end;
-				end += sizeof (PacketHeader);
-				buffer_pos += sizeof (PacketHeader);
+		else if (remaining_buffer_size >= sizeof (PacketHeader)) {
+			// printf ("\nremaining_buffer_size >= sizeof (PacketHeader)\n");
+			header = (PacketHeader *) end;
+			end += sizeof (PacketHeader);
+			buffer_pos += sizeof (PacketHeader);
 
-				// packet_header_print (header);
+			// packet_header_print (header);
 
-				spare_header = false;
-			}
+			spare_header = false;
+		}
 
-			if (header) {
-				// check the packet size
-				packet_size = header->packet_size;
-				if ((packet_size > 0) /* && (packet_size < 65536) */) {
-					// printf ("packet_size: %ld\n", packet_size);
-					// end += sizeof (PacketHeader);
-					// buffer_pos += sizeof (PacketHeader);
-					// printf ("first buffer pos: %ld\n", buffer_pos);
+		if (header) {
+			// check the packet size
+			packet_size = header->packet_size;
+			if ((packet_size > 0) /* && (packet_size < 65536) */) {
+				// printf ("packet_size: %ld\n", packet_size);
+				// end += sizeof (PacketHeader);
+				// buffer_pos += sizeof (PacketHeader);
+				// printf ("first buffer pos: %ld\n", buffer_pos);
 
-					Packet *packet = packet_new ();
-					if (packet) {
-						packet_header_copy (&packet->header, header);
-						packet->packet_size = header->packet_size;
-						// packet->cerver = cerver;
-						// packet->lobby = lobby;
-						packet->client = client;
-						packet->connection = connection;
+				Packet *packet = packet_new ();
+				if (packet) {
+					packet_header_copy (&packet->header, header);
+					packet->packet_size = header->packet_size;
+					// packet->cerver = cerver;
+					// packet->lobby = lobby;
+					packet->client = client;
+					packet->connection = connection;
 
-						if (spare_header) {
-							free (header);
-							header = NULL;
-						}
+					if (spare_header) {
+						free (header);
+						header = NULL;
+					}
 
-						// check for packet size and only copy what is in the current buffer
-						packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
-						to_copy_size = 0;
-						if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
-							sock_receive->spare_packet = packet;
+					// check for packet size and only copy what is in the current buffer
+					packet_real_size = packet->header->packet_size - sizeof (PacketHeader);
+					to_copy_size = 0;
+					if ((remaining_buffer_size - sizeof (PacketHeader)) < packet_real_size) {
+						sock_receive->spare_packet = packet;
 
-							if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
-							else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+						if (spare_header) to_copy_size = buffer_size - sock_receive->remaining_header;
+						else to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
 
-							sock_receive->missing_packet = packet_real_size - to_copy_size;
-						}
-
-						else {
-							if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
-								to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
-							}
-
-							else {
-								to_copy_size = packet_real_size;
-							}
-
-							packet_delete (sock_receive->spare_packet);
-							sock_receive->spare_packet = NULL;
-						}
-
-						// printf ("to copy size: %ld\n", to_copy_size);
-						packet_set_data (packet, (void *) end, to_copy_size);
-
-						end += to_copy_size;
-						buffer_pos += to_copy_size;
-						// printf ("second buffer pos: %ld\n", buffer_pos);
-
-						if (!sock_receive->spare_packet) {
-							connection->full_packet = true;
-							client_packet_handler (packet);
-						}
+						sock_receive->missing_packet = packet_real_size - to_copy_size;
 					}
 
 					else {
-						client_log (
-							LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-							"Failed to create a new packet in cerver_handle_receive_buffer ()"
-						);
+						if ((header->packet_type == PACKET_TYPE_REQUEST) && (header->request_type == REQUEST_PACKET_TYPE_SEND_FILE)) {
+							to_copy_size = remaining_buffer_size - sizeof (PacketHeader);
+						}
+
+						else {
+							to_copy_size = packet_real_size;
+						}
+
+						packet_delete (sock_receive->spare_packet);
+						sock_receive->spare_packet = NULL;
+					}
+
+					// printf ("to copy size: %ld\n", to_copy_size);
+					packet_set_data (packet, (void *) end, to_copy_size);
+
+					end += to_copy_size;
+					buffer_pos += to_copy_size;
+					// printf ("second buffer pos: %ld\n", buffer_pos);
+
+					if (!sock_receive->spare_packet) {
+						connection->full_packet = true;
+						client_packet_handler (packet);
 					}
 				}
 
 				else {
 					client_log (
-						LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
-						"Got a packet of invalid size: %ld", packet_size
+						LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+						"Failed to create a new packet in cerver_handle_receive_buffer ()"
 					);
-
-					break;
 				}
 			}
 
 			else {
-				if (sock_receive->spare_packet) {
-					// printf ("else sock_receive->spare_packet\n");
-					packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
-				}
+				client_log (
+					LOG_TYPE_WARNING, LOG_TYPE_CLIENT,
+					"Got a packet of invalid size: %ld", packet_size
+				);
 
-				else {
-					// handle part of a new header
-					// #ifdef CERVER_DEBUG
-					// client_log_debug ("Handle part of a new header...");
-					// #endif
+				break;
+			}
+		}
 
-					// printf ("buffer size: %ld\n", buffer_size);
-					// printf ("buffer pos: %ld\n", buffer_pos);
-					// printf ("remaining_buffer_size: %ld\n", remaining_buffer_size);
-
-					// copy the piece of possible header that was cut of between recv ()
-					sock_receive->header = malloc (sizeof (PacketHeader));
-					memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
-
-					sock_receive->header_end = (char *) sock_receive->header;
-					sock_receive->header_end += remaining_buffer_size;
-
-					// sock_receive->curr_header_pos = remaining_buffer_size;
-					sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
-
-					// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
-					// printf ("remaining header: %d\n", sock_receive->remaining_header);
-
-					buffer_pos += remaining_buffer_size;
-				}
+		else {
+			if (sock_receive->spare_packet) {
+				// printf ("else sock_receive->spare_packet\n");
+				packet_append_data (sock_receive->spare_packet, (void *) end, remaining_buffer_size);
 			}
 
-			header = NULL;
+			else {
+				// handle part of a new header
+				// #ifdef CERVER_DEBUG
+				// client_log_debug ("Handle part of a new header...");
+				// #endif
+
+				// printf ("buffer size: %ld\n", buffer_size);
+				// printf ("buffer pos: %ld\n", buffer_pos);
+				// printf ("remaining_buffer_size: %ld\n", remaining_buffer_size);
+
+				// copy the piece of possible header that was cut of between recv ()
+				sock_receive->header = malloc (sizeof (PacketHeader));
+				memcpy (sock_receive->header, (void *) end, remaining_buffer_size);
+
+				sock_receive->header_end = (char *) sock_receive->header;
+				sock_receive->header_end += remaining_buffer_size;
+
+				// sock_receive->curr_header_pos = remaining_buffer_size;
+				sock_receive->remaining_header = sizeof (PacketHeader) - remaining_buffer_size;
+
+				// printf ("curr header pos: %d\n", sock_receive->curr_header_pos);
+				// printf ("remaining header: %d\n", sock_receive->remaining_header);
+
+				buffer_pos += remaining_buffer_size;
+			}
 		}
+
+		header = NULL;
 	}
 
 }
@@ -762,7 +760,7 @@ unsigned int client_receive_internal (
 				#endif
 
 				client_receive_handle_failed (client, connection);
-					}
+			}
 		} break;
 
 		case 0: {
@@ -789,10 +787,10 @@ unsigned int client_receive_internal (
 			client->stats->n_receives_done += 1;
 			client->stats->total_bytes_received += rc;
 
-					connection->stats->n_receives_done += 1;
-					connection->stats->total_bytes_received += rc;
+			connection->stats->n_receives_done += 1;
+			connection->stats->total_bytes_received += rc;
 
-					// handle the recived packet buffer -> split them in packets of the correct size
+			// handle the recived packet buffer -> split them in packets of the correct size
 			client_receive_handle_buffer (
 				client,
 				connection,

--- a/src/client/handler.c
+++ b/src/client/handler.c
@@ -724,80 +724,118 @@ static void client_receive_handle_failed (Client *client, Connection *connection
 
 }
 
-// receives incoming data from the socket
-void client_receive (Client *client, Connection *connection) {
+// receive data from connection's socket
+// this method does not perform any checks and expects a valid buffer
+// to handle incomming data
+// returns 0 on success, 1 on error
+unsigned int client_receive_internal (
+	Client *client, Connection *connection,
+	char *buffer, const size_t buffer_size
+) {
 
-	if (client && connection) {
-		char *packet_buffer = (char *) calloc (connection->receive_packet_buffer_size, sizeof (char));
-		if (packet_buffer) {
-			ssize_t rc = recv (connection->socket->sock_fd, packet_buffer, connection->receive_packet_buffer_size, 0);
+	unsigned int retval = 1;
 
-			switch (rc) {
-				case -1: {
-					if (errno != EWOULDBLOCK) {
-						#ifdef HANDLER_DEBUG
-						client_log (
-							LOG_TYPE_ERROR, LOG_TYPE_NONE,
-							"client_receive () - rc < 0 - sock fd: %d", connection->socket->sock_fd
-						);
-						perror ("Error");
-						#endif
+	ssize_t rc = recv (connection->socket->sock_fd, buffer, buffer_size, 0);
+	switch (rc) {
+		case -1: {
+			if (errno == EAGAIN) {
+				#ifdef CONNECTION_DEBUG
+				client_log (
+					LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+					"client_receive_internal () - connection %s sock fd: %d timed out",
+					connection->name->str, connection->socket->sock_fd
+				);
+				#endif
 
-						client_receive_handle_failed (client, connection);
+				retval = 0;
+			}
+
+			else {
+				#ifdef CONNECTION_DEBUG
+				client_log (
+					LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
+					"client_receive_internal () - rc < 0 - connection %s sock fd: %d",
+					connection->name->str, connection->socket->sock_fd
+				);
+
+				perror ("Error ");
+				#endif
+
+				client_receive_handle_failed (client, connection);
 					}
-				} break;
+		} break;
 
-				case 0: {
-					// man recv -> steam socket perfomed an orderly shutdown
-					// but in dgram it might mean something?
-					#ifdef HANDLER_DEBUG
-					client_log (
-						LOG_TYPE_DEBUG, LOG_TYPE_NONE,
-						"client_receive () - rc == 0 - sock fd: %d",
-						connection->socket->sock_fd
-					);
-					// perror ("Error");
-					#endif
+		case 0: {
+			#ifdef CONNECTION_DEBUG
+			client_log (
+				LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+				"client_receive_internal () - rc == 0 - connection %s sock fd: %d",
+				connection->name->str, connection->socket->sock_fd
+			);
 
-					client_receive_handle_failed (client, connection);
-				} break;
+			// perror ("Error ");
+			#endif
 
-				default: {
-					// char *s = c_string_create ("Connection %s rc: %ld",
-					//     connection->name->str, rc);
-					// if (s) {
-					//     client_log (stdout, LOG_TYPE_DEBUG, LOG_TYPE_CLIENT, s);
-					//     free (s);
-					// }
+			client_receive_handle_failed (client, connection);
+		} break;
 
-					client->stats->n_receives_done += 1;
-					client->stats->total_bytes_received += rc;
+		default: {
+			// client_log (
+			// 	LOG_TYPE_DEBUG, LOG_TYPE_CLIENT,
+			// 	"Connection %s rc: %ld",
+			// 	connection->name->str, rc
+			// );
+
+			client->stats->n_receives_done += 1;
+			client->stats->total_bytes_received += rc;
 
 					connection->stats->n_receives_done += 1;
 					connection->stats->total_bytes_received += rc;
 
 					// handle the recived packet buffer -> split them in packets of the correct size
-					client_receive_handle_buffer (
-						client,
-						connection,
-						packet_buffer,
-						rc
-					);
-				} break;
-			}
+			client_receive_handle_buffer (
+				client,
+				connection,
+				buffer,
+				rc
+			);
+
+			retval = 0;
+		} break;
+	}
+
+	return retval;
+
+}
+
+// allocates a new packet buffer to receive incoming data from the connection's socket
+// returns 0 on success handle, 1 if any error ocurred and must likely the connection was ended
+unsigned int client_receive (Client *client, Connection *connection) {
+
+	unsigned int retval = 1;
+
+	if (client && connection) {
+		char *packet_buffer = (char *) calloc (connection->receive_packet_buffer_size, sizeof (char));
+		if (packet_buffer) {
+			retval = client_receive_internal (
+				client, connection,
+				packet_buffer, connection->receive_packet_buffer_size
+			);
 
 			free (packet_buffer);
 		}
 
 		else {
-			#ifdef HANDLER_DEBUG
+			// #ifdef CLIENT_DEBUG
 			client_log (
-				LOG_TYPE_ERROR, LOG_TYPE_CLIENT,
-				"Failed to allocate a new packet buffer!"
+				LOG_TYPE_ERROR, LOG_TYPE_CONNECTION,
+				"client_receive () - Failed to allocate a new packet buffer!"
 			);
-			#endif
+			// #endif
 		}
 	}
+
+	return retval;
 
 }
 

--- a/src/client/input.c
+++ b/src/client/input.c
@@ -60,7 +60,6 @@ unsigned int input_password (char *password) {
 		new_term = old_term;
 		new_term.c_lflag &= ~ECHO;
 		if (!tcsetattr (fileno (stdin), TCSAFLUSH, &new_term) != 0) {
-			printf ("Enter password: ");
 			scanf ("%128s", password);
 
 			/* Restore terminal. */

--- a/src/client/packets.c
+++ b/src/client/packets.c
@@ -349,7 +349,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 
 			else {
 				#ifdef PACKETS_DEBUG
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to realloc packet data!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to realloc packet data!");
 				#endif
 				packet->data = NULL;
 				packet->data_size = 0;
@@ -374,7 +374,7 @@ u8 packet_append_data (Packet *packet, void *data, size_t data_size) {
 
 			else {
 				#ifdef PACKETS_DEBUG
-				client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to allocate packet data!");
+				client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to allocate packet data!");
 				#endif
 				packet->data = NULL;
 				packet->data_size = 0;
@@ -970,14 +970,14 @@ bool packet_check (Packet *packet) {
 
 				else {
 					#ifdef PACKETS_DEBUG
-					client_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with incompatible version.");
+					client_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with incompatible version.");
 					#endif
 				}
 			}
 
 			else {
 				#ifdef PACKETS_DEBUG
-				client_log_msg (stdout, LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with unknown protocol ID.");
+				client_log (LOG_TYPE_WARNING, LOG_TYPE_PACKET, "Packet with unknown protocol ID.");
 				#endif
 			}
 		}

--- a/src/client/threads/thread.c
+++ b/src/client/threads/thread.c
@@ -27,7 +27,7 @@ u8 thread_create_detachable (pthread_t *thread, void *(*work) (void *), void *ar
 				}
 
 				else {
-					client_log_msg (stderr, LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create detachable thread!");
+					client_log (LOG_TYPE_ERROR, LOG_TYPE_NONE, "Failed to create detachable thread!");
 					perror ("Error");
 				}
 			}

--- a/src/client/timer.c
+++ b/src/client/timer.c
@@ -7,7 +7,7 @@
 #include "client/types/types.h"
 #include "client/types/string.h"
 
-#include "client/time.h"
+#include "client/timer.h"
 
 static TimeSpec *timespec_new (void) {
 

--- a/src/client/utils/log.c
+++ b/src/client/utils/log.c
@@ -442,7 +442,7 @@ static void client_log_internal (
 
 // creates and prints a message of custom types
 // based on the first type, the message can be printed with colors to stdout
-void cerver_log (
+void client_log (
 	LogType first_type, LogType second_type,
 	const char *format, ...
 ) {
@@ -577,9 +577,9 @@ void client_log_init (void) {
 
 			logfile = fopen (filename, "w+");
 			if (logfile) {
-				fprintf (logfile, "\nCerver Version: %s\n", CLIENT_VERSION_NAME);
-				fprintf (logfile, "Release Date & time: %s - %s\n", CLIENT_VERSION_DATE, CLIENT_VERSION_TIME);
-				fprintf (logfile, "Author: %s\n\n", CLIENT_VERSION_AUTHOR);
+				printf ("\n\nCerver Client Version: %s\n", CLIENT_VERSION_NAME);
+				printf ("Release Date & time: %s - %s\n", CLIENT_VERSION_DATE, CLIENT_VERSION_TIME);
+				printf ("Author: %s\n\n", CLIENT_VERSION_AUTHOR);
 			}
 
 			else {

--- a/src/client/utils/log.c
+++ b/src/client/utils/log.c
@@ -1,9 +1,17 @@
-#include <stdio.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
+
+#include <stdarg.h>
+
+#include "client/collections/pool.h"
 
 #include "client/utils/utils.h"
 #include "client/utils/log.h"
+
+static Pool *log_pool = NULL;
+
+#pragma region types
 
 static const char *log_get_msg_type (LogType type) {
 
@@ -11,9 +19,170 @@ static const char *log_get_msg_type (LogType type) {
 		#define XX(num, name, string) case LOG_TYPE_##name: return #string;
 		LOG_TYPE_MAP(XX)
 		#undef XX
+
+		default: return log_get_msg_type (LOG_TYPE_NONE);
 	}
 
-	return log_get_msg_type (LOG_TYPE_NONE);
+}
+
+#pragma endregion
+
+#pragma region internal
+
+typedef struct {
+
+	char header[LOG_HEADER_SIZE];
+	char *second;
+
+	char message[LOG_MESSAGE_SIZE];
+
+} ClientLog;
+
+static void *client_log_new (void) {
+
+	ClientLog *log = (ClientLog *) malloc (sizeof (ClientLog));
+	if (log) {
+		memset (log->header, 0, LOG_HEADER_SIZE);
+		log->second = log->header + LOG_HEADER_HALF_SIZE;
+
+		memset (log->message, 0, LOG_MESSAGE_SIZE);
+	}
+
+	return log;
+
+}
+
+static void client_log_delete (void *client_log_ptr) {
+
+	if (client_log_ptr) free (client_log_ptr);
+
+}
+
+static void client_log_header_create (
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	const char *first = log_get_msg_type (first_type);
+	if (second_type != LOG_TYPE_NONE) {
+		switch (first_type) {
+			case LOG_TYPE_DEBUG:
+			case LOG_TYPE_TEST: {
+				// first type
+				(void) snprintf (
+					log->header, LOG_HEADER_HALF_SIZE, 
+					"%s", 
+					first
+				);
+
+				// second type
+				(void) snprintf (
+					log->second, LOG_HEADER_HALF_SIZE, 
+					"%s", 
+					log_get_msg_type (second_type)
+				);
+			} break;
+
+			default: {
+				(void) snprintf (
+					log->header, LOG_HEADER_SIZE, 
+					"%s%s", 
+					first, log_get_msg_type (second_type)
+				);
+			} break;
+		}
+	}
+
+	else {
+		(void) snprintf (
+			log->header, LOG_HEADER_SIZE,
+			"%s",
+			first
+		);
+	}
+
+}
+
+static FILE *client_log_get_stream (LogType first_type) {
+
+	FILE *retval = stdout;
+
+	switch (first_type) {
+		case LOG_TYPE_ERROR:
+		case LOG_TYPE_WARNING:
+			retval = stderr;
+			break;
+
+		default: break;
+	}
+
+	return retval;
+
+}
+
+static void client_log_internal (
+	FILE *__restrict __stream,
+	LogType first_type, LogType second_type,
+	const char *format, va_list args
+) {
+
+	ClientLog *log = (ClientLog *) pool_pop (log_pool);
+	if (log) {
+		client_log_header_create (log, first_type, second_type);
+		(void) vsnprintf (log->message, LOG_MESSAGE_SIZE, format, args);
+
+		switch (first_type) {
+			case LOG_TYPE_ERROR: fprintf (__stream, LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+			case LOG_TYPE_WARNING: fprintf (__stream, LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+			case LOG_TYPE_SUCCESS: fprintf (__stream, LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+			case LOG_TYPE_DEBUG: {
+				if (second_type != LOG_TYPE_NONE)
+					fprintf (__stream, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+				else fprintf (__stream, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+			} break;
+			
+			case LOG_TYPE_TEST: {
+				if (second_type != LOG_TYPE_NONE)
+					fprintf (__stream, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+				else fprintf (__stream, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+			} break;
+
+			case LOG_TYPE_CERVER: fprintf (__stream, LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+			case LOG_TYPE_EVENT: fprintf (__stream, LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+			default: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		}
+
+		pool_push (log_pool, log);
+	}
+
+}
+
+#pragma endregion
+
+#pragma region public
+
+void client_log (
+	LogType first_type, LogType second_type,
+	const char *format, ...
+) {
+
+	if (format) {
+		va_list args = { 0 };
+		va_start (args, format);
+
+		client_log_internal (
+			client_log_get_stream (first_type),
+			first_type, second_type,
+			format, args
+		);
+
+		va_end (args);
+	}
 
 }
 
@@ -24,100 +193,87 @@ void client_log_msg (
 ) {
 
 	if (__stream && msg) {
-		const char *first = log_get_msg_type (first_type);
-		if (first) {
-			char *message = NULL;
+		va_list args = { 0 };
 
-			if (second_type != LOG_TYPE_NONE) {
-				const char *second = log_get_msg_type (second_type);
-				if (second) {
-					switch (first_type) {
-						case LOG_TYPE_DEBUG:
-						case LOG_TYPE_TEST:
-							message = c_string_create ("%s: %s\n", second, msg);
-							break;
-
-						default: 
-							message = c_string_create ("%s%s: %s\n", first, second, msg);
-							break;
-					}
-				}
-			}
-
-			else {
-				switch (first_type) {
-					case LOG_TYPE_DEBUG:
-					case LOG_TYPE_TEST:
-						break;
-
-					default: 
-						message = c_string_create ("%s: %s\n", first, msg);
-						break;
-				}
-			}
-
-			if (message) {
-				switch (first_type) {
-					case LOG_TYPE_DEBUG: fprintf (__stream, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s", first, message); break;
-					
-					case LOG_TYPE_TEST: fprintf (__stream, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s", first, message); break;
-
-					case LOG_TYPE_ERROR: fprintf (__stream, LOG_COLOR_RED "%s" LOG_COLOR_RESET, message); break;
-					case LOG_TYPE_WARNING: fprintf (__stream, LOG_COLOR_YELLOW "%s" LOG_COLOR_RESET, message); break;
-					case LOG_TYPE_SUCCESS: fprintf (__stream, LOG_COLOR_GREEN "%s" LOG_COLOR_RESET, message); break;
-
-					case LOG_TYPE_CERVER: fprintf (__stream, LOG_COLOR_BLUE "%s" LOG_COLOR_RESET, message); break;
-
-					case LOG_TYPE_EVENT: fprintf (__stream, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET, message); break;
-
-					default: fprintf (__stream, "%s", message); break;
-				}
-
-				free (message);
-			}
-
-			else {
-				switch (first_type) {
-					case LOG_TYPE_DEBUG: 
-						fprintf (__stream, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", first, msg); 
-						break;
-					
-					case LOG_TYPE_TEST: 
-						fprintf (__stream, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", first, msg);
-						break;
-
-					default: break;
-				}
-			}
-		}
+		client_log_internal (
+			__stream,
+			first_type, second_type,
+			msg, args
+		);
 	}
 
 }
 
 // prints a red error message to stderr
-void client_log_error (const char *msg) {
+void client_log_error (const char *msg, ...) {
 
-	if (msg) fprintf (stderr, LOG_COLOR_RED "[ERROR]: " "%s\n" LOG_COLOR_RESET, msg);
+	if (msg) {
+		va_list args = { 0 };
+		va_start (args, msg);
+
+		client_log_internal (
+			stderr,
+			LOG_TYPE_ERROR, LOG_TYPE_NONE,
+			msg, args
+		);
+
+		va_end (args);
+	}
 
 }
 
 // prints a yellow warning message to stderr
-void client_log_warning (const char *msg) {
+void client_log_warning (const char *msg, ...) {
 
-	if (msg) fprintf (stderr, LOG_COLOR_YELLOW "[WARNING]: " "%s\n" LOG_COLOR_RESET, msg);
+	if (msg) {
+		va_list args = { 0 };
+		va_start (args, msg);
+
+		client_log_internal (
+			stderr,
+			LOG_TYPE_WARNING, LOG_TYPE_NONE,
+			msg, args
+		);
+
+		va_end (args);
+	}
 
 }
 
 // prints a green success message to stdout
-void client_log_success (const char *msg) {
+void client_log_success (const char *msg, ...) {
 
-	if (msg) fprintf (stdout, LOG_COLOR_GREEN "[SUCCESS]: " "%s\n" LOG_COLOR_RESET, msg);
+	if (msg) {
+		va_list args = { 0 };
+		va_start (args, msg);
+
+		client_log_internal (
+			stdout,
+			LOG_TYPE_SUCCESS, LOG_TYPE_NONE,
+			msg, args
+		);
+
+		va_end (args);
+	}
 
 }
 
 // prints a debug message to stdout
-void client_log_debug (const char *msg) {
+void client_log_debug (const char *msg, ...) {
 
-	if (msg) fprintf (stdout, LOG_COLOR_MAGENTA "[DEBUG]: " LOG_COLOR_RESET "%s\n", msg);
+	if (msg) {
+		va_list args = { 0 };
+		va_start (args, msg);
+
+		client_log_internal (
+			stdout,
+			LOG_TYPE_DEBUG, LOG_TYPE_NONE,
+			msg, args
+		);
+
+		va_end (args);
+	}
 
 }
+
+#pragma endregion

--- a/src/client/utils/log.c
+++ b/src/client/utils/log.c
@@ -277,3 +277,25 @@ void client_log_debug (const char *msg, ...) {
 }
 
 #pragma endregion
+
+#pragma region main
+
+void client_log_init (void) {
+
+	if (!log_pool) {
+		log_pool = pool_create (client_log_delete);
+		pool_set_create (log_pool, client_log_new);
+		pool_set_produce_if_empty (log_pool, true);
+		pool_init (log_pool, client_log_new, LOG_POOL_INIT);
+	}
+
+}
+
+void client_log_end (void) {
+
+	pool_delete (log_pool);
+	log_pool = NULL;
+
+}
+
+#pragma endregion

--- a/src/client/utils/log.c
+++ b/src/client/utils/log.c
@@ -172,7 +172,7 @@ void client_log (
 ) {
 
 	if (format) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, format);
 
 		client_log_internal (
@@ -193,7 +193,7 @@ void client_log_msg (
 ) {
 
 	if (__stream && msg) {
-		va_list args = { 0 };
+		va_list args;
 
 		client_log_internal (
 			__stream,
@@ -208,7 +208,7 @@ void client_log_msg (
 void client_log_error (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		client_log_internal (
@@ -226,7 +226,7 @@ void client_log_error (const char *msg, ...) {
 void client_log_warning (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		client_log_internal (
@@ -244,7 +244,7 @@ void client_log_warning (const char *msg, ...) {
 void client_log_success (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		client_log_internal (
@@ -262,7 +262,7 @@ void client_log_success (const char *msg, ...) {
 void client_log_debug (const char *msg, ...) {
 
 	if (msg) {
-		va_list args = { 0 };
+		va_list args;
 		va_start (args, msg);
 
 		client_log_internal (

--- a/src/client/utils/log.c
+++ b/src/client/utils/log.c
@@ -1,15 +1,20 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdbool.h>
 
 #include <stdarg.h>
+#include <time.h>
+
+#include "client/types/string.h"
 
 #include "client/collections/pool.h"
 
+#include "client/files.h"
+#include "client/version.h"
+
 #include "client/utils/utils.h"
 #include "client/utils/log.h"
-
-static Pool *log_pool = NULL;
 
 #pragma region types
 
@@ -27,10 +32,108 @@ static const char *log_get_msg_type (LogType type) {
 
 #pragma endregion
 
+#pragma region configuration
+
+static LogOutputType log_output_type = LOG_OUTPUT_TYPE_STD;
+
+static LogTimeType log_time_type = LOG_TIME_TYPE_NONE;
+static bool use_local_time = false;
+
+static String *logs_pathname = NULL;
+static FILE *logfile = NULL;
+
+// returns the current log output type
+LogOutputType client_log_get_output_type (void) {
+
+	return log_output_type;
+
+}
+
+// sets the log output type to use
+void client_log_set_output_type (LogOutputType type) {
+
+	log_output_type = type;
+
+}
+
+// sets the path where logs files will be stored
+// returns 0 on success, 1 on error
+unsigned int client_log_set_path (const char *pathname) {
+
+	unsigned int retval = 1;
+
+	if (pathname) {
+		if (!file_exists (pathname)) {
+			if (!files_create_dir (pathname, 0755)) {
+				logs_pathname = str_new (pathname);
+				retval = 0;
+			}
+		}
+
+		else {
+			logs_pathname = str_new (pathname);
+			retval = 0;
+		}
+	}
+
+	return retval;
+
+}
+
+const char *client_log_time_type_to_string (LogTimeType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case LOG_TIME_TYPE_##name: return #string;
+		LOG_TIME_TYPE_MAP(XX)
+		#undef XX
+
+		default: return client_log_time_type_to_string (LOG_TIME_TYPE_NONE);
+	}
+
+}
+
+const char *client_log_time_type_description (LogTimeType type) {
+
+	switch (type) {
+		#define XX(num, name, string, description) case LOG_TIME_TYPE_##name: return #description;
+		LOG_TIME_TYPE_MAP(XX)
+		#undef XX
+
+		default: return client_log_time_type_description (LOG_TIME_TYPE_NONE);
+	}
+
+}
+
+// returns the current log time configuration
+LogTimeType client_log_get_time_config (void) {
+
+	return log_time_type;
+
+}
+
+// sets the log time configuration to be used by log methods
+// none: print logs with no dates
+// time: 24h time format
+// date: day/month/year format
+// both: day/month/year - 24h date time format
+void client_log_set_time_config (LogTimeType type) {
+
+	log_time_type = type;
+
+}
+
+// set if logs datetimes will use local time or not
+void client_log_set_local_time (bool value) { use_local_time = value; }
+
+#pragma endregion
+
 #pragma region internal
+
+static Pool *log_pool = NULL;
 
 typedef struct {
 
+	char datetime[LOG_DATETIME_SIZE];
 	char header[LOG_HEADER_SIZE];
 	char *second;
 
@@ -42,6 +145,7 @@ static void *client_log_new (void) {
 
 	ClientLog *log = (ClientLog *) malloc (sizeof (ClientLog));
 	if (log) {
+		memset (log->datetime, 0, LOG_DATETIME_SIZE);
 		memset (log->header, 0, LOG_HEADER_SIZE);
 		log->second = log->header + LOG_HEADER_HALF_SIZE;
 
@@ -107,16 +211,193 @@ static FILE *client_log_get_stream (LogType first_type) {
 
 	FILE *retval = stdout;
 
+	if (logfile) retval = logfile;
+	else {
+		switch (first_type) {
+			case LOG_TYPE_ERROR:
+			case LOG_TYPE_WARNING:
+				retval = stderr;
+				break;
+
+			default: break;
+		}
+	}
+
+	return retval;
+
+}
+
+static void client_log_internal_normal_std (
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
 	switch (first_type) {
-		case LOG_TYPE_ERROR:
-		case LOG_TYPE_WARNING:
-			retval = stderr;
+		case LOG_TYPE_NONE: fprintf (stdout, "%s\n", log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (stderr, LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (stderr, LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (stdout, LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+			else fprintf (stdout, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+
+			else fprintf (stdout, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (stdout, LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (stdout, LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+
+		default: fprintf (stdout, "%s: %s\n", log->header, log->message); break;
+	}
+
+}
+
+static void client_log_internal_normal_file (
+	FILE *__restrict __stream,
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (__stream, "%s\n", log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE) fprintf (__stream, "%s%s: %s\n", log->header, log->second, log->message);
+			else fprintf (__stream,  "%s: %s\n", log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE) fprintf (__stream, "%s%s: %s\n", log->header, log->second, log->message);
+			else fprintf (__stream, "%s: %s\n", log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+
+		default: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+	}
+
+}
+
+static void client_log_internal_normal (
+	FILE *__restrict __stream,
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_STD: client_log_internal_normal_std (log, first_type, second_type); break;
+		case LOG_OUTPUT_TYPE_FILE: client_log_internal_normal_file (__stream, log, first_type, second_type); break;
+
+		case LOG_OUTPUT_TYPE_BOTH:
+			client_log_internal_normal_std (log, first_type, second_type);
+			client_log_internal_normal_file (__stream, log, first_type, second_type);
 			break;
 
 		default: break;
 	}
 
-	return retval;
+}
+
+static void client_log_internal_with_time_std (
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (stdout, "[%s]: %s\n", log->datetime, log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (stderr, "[%s]" LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (stderr, "[%s]" LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (stdout, "[%s]" LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->datetime, log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (stdout, "[%s]" LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (stdout, "[%s]" LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->datetime, log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (stdout, "[%s]" LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (stdout, "[%s]" LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->datetime, log->header, log->message); break;
+
+		default: fprintf (stdout, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+	}
+
+}
+
+static void client_log_internal_with_time_file (
+	FILE *__restrict __stream,
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (first_type) {
+		case LOG_TYPE_NONE: fprintf (__stream, "[%s]: %s\n", log->datetime, log->message); break;
+
+		case LOG_TYPE_ERROR: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_WARNING: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_SUCCESS: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+
+		case LOG_TYPE_DEBUG: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (__stream, "[%s]%s%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message);
+		} break;
+		
+		case LOG_TYPE_TEST: {
+			if (second_type != LOG_TYPE_NONE)
+				fprintf (__stream, "[%s]%s%s: %s\n", log->datetime, log->header, log->second, log->message);
+
+			else fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message);
+		} break;
+
+		case LOG_TYPE_CERVER: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+		case LOG_TYPE_EVENT: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+
+		default: fprintf (__stream, "[%s]%s: %s\n", log->datetime, log->header, log->message); break;
+	}
+
+}
+
+static void client_log_internal_with_time (
+	FILE *__restrict __stream,
+	ClientLog *log,
+	LogType first_type, LogType second_type
+) {
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_STD: client_log_internal_with_time_std (log, first_type, second_type); break;
+		case LOG_OUTPUT_TYPE_FILE: client_log_internal_with_time_file (__stream, log, first_type, second_type); break;
+
+		case LOG_OUTPUT_TYPE_BOTH:
+			client_log_internal_with_time_std (log, first_type, second_type);
+			client_log_internal_with_time_file (__stream, log, first_type, second_type);
+			break;
+
+		default: break;
+	}
 
 }
 
@@ -128,33 +409,26 @@ static void client_log_internal (
 
 	ClientLog *log = (ClientLog *) pool_pop (log_pool);
 	if (log) {
-		client_log_header_create (log, first_type, second_type);
+		if (first_type != LOG_TYPE_NONE) client_log_header_create (log, first_type, second_type);
 		(void) vsnprintf (log->message, LOG_MESSAGE_SIZE, format, args);
 
-		switch (first_type) {
-			case LOG_TYPE_ERROR: fprintf (__stream, LOG_COLOR_RED "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-			case LOG_TYPE_WARNING: fprintf (__stream, LOG_COLOR_YELLOW "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-			case LOG_TYPE_SUCCESS: fprintf (__stream, LOG_COLOR_GREEN "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
+		if (log_time_type != LOG_TIME_TYPE_NONE) {
+			time_t datetime = time (NULL);
+			struct tm *timeinfo = use_local_time ? localtime (&datetime) : gmtime (&datetime);
 
-			case LOG_TYPE_DEBUG: {
-				if (second_type != LOG_TYPE_NONE)
-					fprintf (__stream, LOG_COLOR_MAGENTA "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+			switch (log_time_type) {
+				case LOG_TIME_TYPE_TIME: strftime (log->datetime, LOG_DATETIME_SIZE, "%T", timeinfo); break;
+				case LOG_TIME_TYPE_DATE: strftime (log->datetime, LOG_DATETIME_SIZE, "%d/%m/%y", timeinfo); break;
+				case LOG_TIME_TYPE_BOTH: strftime (log->datetime, LOG_DATETIME_SIZE, "%d/%m/%y - %T", timeinfo); break;
 
-				else fprintf (__stream, LOG_COLOR_MAGENTA "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
-			} break;
-			
-			case LOG_TYPE_TEST: {
-				if (second_type != LOG_TYPE_NONE)
-					fprintf (__stream, LOG_COLOR_CYAN "%s" LOG_COLOR_RESET "%s: %s\n", log->header, log->second, log->message);
+				default: break;
+			}
 
-				else fprintf (__stream, LOG_COLOR_CYAN "%s: " LOG_COLOR_RESET "%s\n", log->header, log->message);
-			} break;
+			client_log_internal_with_time (__stream, log, first_type, second_type);
+		}
 
-			case LOG_TYPE_CERVER: fprintf (__stream, LOG_COLOR_BLUE "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-
-			case LOG_TYPE_EVENT: fprintf (__stream, LOG_COLOR_MAGENTA "%s: %s\n" LOG_COLOR_RESET, log->header, log->message); break;
-
-			default: fprintf (__stream, "%s: %s\n", log->header, log->message); break;
+		else {
+			client_log_internal_normal (__stream, log, first_type, second_type);
 		}
 
 		pool_push (log_pool, log);
@@ -166,7 +440,9 @@ static void client_log_internal (
 
 #pragma region public
 
-void client_log (
+// creates and prints a message of custom types
+// based on the first type, the message can be printed with colors to stdout
+void cerver_log (
 	LogType first_type, LogType second_type,
 	const char *format, ...
 ) {
@@ -186,20 +462,20 @@ void client_log (
 
 }
 
-void client_log_msg (
-	FILE *__restrict __stream, 
-	LogType first_type, LogType second_type,
-	const char *msg
-) {
+// prints a message with no type, effectively making this a custom printf ()
+void client_log_msg (const char *msg, ...) {
 
-	if (__stream && msg) {
+	if (msg) {
 		va_list args;
+		va_start (args, msg);
 
 		client_log_internal (
-			__stream,
-			first_type, second_type,
+			client_log_get_stream (LOG_TYPE_NONE),
+			LOG_TYPE_NONE, LOG_TYPE_NONE,
 			msg, args
 		);
+
+		va_end (args);
 	}
 
 }
@@ -212,7 +488,7 @@ void client_log_error (const char *msg, ...) {
 		va_start (args, msg);
 
 		client_log_internal (
-			stderr,
+			client_log_get_stream (LOG_TYPE_ERROR),
 			LOG_TYPE_ERROR, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -230,7 +506,7 @@ void client_log_warning (const char *msg, ...) {
 		va_start (args, msg);
 
 		client_log_internal (
-			stderr,
+			client_log_get_stream (LOG_TYPE_WARNING),
 			LOG_TYPE_WARNING, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -248,7 +524,7 @@ void client_log_success (const char *msg, ...) {
 		va_start (args, msg);
 
 		client_log_internal (
-			stdout,
+			client_log_get_stream (LOG_TYPE_SUCCESS),
 			LOG_TYPE_SUCCESS, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -266,7 +542,7 @@ void client_log_debug (const char *msg, ...) {
 		va_start (args, msg);
 
 		client_log_internal (
-			stdout,
+			client_log_get_stream (LOG_TYPE_DEBUG),
 			LOG_TYPE_DEBUG, LOG_TYPE_NONE,
 			msg, args
 		);
@@ -289,9 +565,43 @@ void client_log_init (void) {
 		pool_init (log_pool, client_log_new, LOG_POOL_INIT);
 	}
 
+	if (!logs_pathname) {
+		logs_pathname = str_new (LOG_DEFAULT_PATH);
+	}
+
+	switch (log_output_type) {
+		case LOG_OUTPUT_TYPE_FILE:
+		case LOG_OUTPUT_TYPE_BOTH: {
+			char filename[1024] = { 0 };
+			snprintf (filename, 1024, "%s/%ld.log", logs_pathname->str, time (NULL));
+
+			logfile = fopen (filename, "w+");
+			if (logfile) {
+				fprintf (logfile, "\nCerver Version: %s\n", CLIENT_VERSION_NAME);
+				fprintf (logfile, "Release Date & time: %s - %s\n", CLIENT_VERSION_DATE, CLIENT_VERSION_TIME);
+				fprintf (logfile, "Author: %s\n\n", CLIENT_VERSION_AUTHOR);
+			}
+
+			else {
+				fprintf (stderr, "\n\nFailed to open %s log file!\n", filename);
+				perror ("Error");
+				printf ("\n\n");
+			}
+		} break;
+
+		default: break;
+	}
+
 }
 
 void client_log_end (void) {
+
+	if (logfile) {
+		fclose (logfile);
+		logfile = NULL;
+	}
+
+	str_delete (logs_pathname);
 
 	pool_delete (log_pool);
 	log_pool = NULL;

--- a/src/client/utils/sha-256.c
+++ b/src/client/utils/sha-256.c
@@ -31,48 +31,52 @@ static const uint32_t k[] = {
 };
 
 struct buffer_state {
+
 	const uint8_t * p;
 	size_t len;
 	size_t total_len;
 	int single_one_delivered; /* bool */
 	int total_len_delivered; /* bool */
+
 };
 
-static inline uint32_t right_rot(uint32_t value, unsigned int count)
-{
-	/*
-	 * Defined behaviour in standard C for all count where 0 < count < 32,
-	 * which is what we need here.
-	 */
+/*
+* Defined behaviour in standard C for all count where 0 < count < 32,
+* which is what we need here.
+*/
+static inline uint32_t right_rot (uint32_t value, unsigned int count) {
+
 	return value >> count | value << (32 - count);
+
 }
 
-static void init_buf_state(struct buffer_state * state, const void * input, size_t len)
-{
-	state->p = (const uint8_t *) input;
+static void init_buf_state (struct buffer_state *state, const void *input, size_t len) {
+
+	state->p = (uint8_t *) input;
 	state->len = len;
 	state->total_len = len;
 	state->single_one_delivered = 0;
 	state->total_len_delivered = 0;
+
 }
 
 /* Return value: bool */
-static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
-{
-	size_t space_in_chunk;
+static int calc_chunk (uint8_t chunk[CHUNK_SIZE], struct buffer_state * state) {
+
+	size_t space_in_chunk = 0;
 
 	if (state->total_len_delivered) {
 		return 0;
 	}
 
 	if (state->len >= CHUNK_SIZE) {
-		memcpy(chunk, state->p, CHUNK_SIZE);
+		memcpy (chunk, state->p, CHUNK_SIZE);
 		state->p += CHUNK_SIZE;
 		state->len -= CHUNK_SIZE;
 		return 1;
 	}
 
-	memcpy(chunk, state->p, state->len);
+	memcpy (chunk, state->p, state->len);
 	chunk += state->len;
 	space_in_chunk = CHUNK_SIZE - state->len;
 	state->p += state->len;
@@ -95,7 +99,7 @@ static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
 		const size_t left = space_in_chunk - TOTAL_LEN_LEN;
 		size_t len = state->total_len;
 		int i;
-		memset(chunk, 0x00, left);
+		memset (chunk, 0x00, left);
 		chunk += left;
 
 		/* Storing of len * 8 as a big endian 64-bit without overflow. */
@@ -122,6 +126,7 @@ static int calc_chunk(uint8_t chunk[CHUNK_SIZE], struct buffer_state * state)
  *   In particular, the len parameter is a number of bytes.
  */
 void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
+
 	/*
 	 * Note 1: All integers (expect indexes) are 32-bit unsigned integers and addition is calculated modulo 2^32.
 	 * Note 2: For each round, there is one round constant k[i] and one entry in the message schedule array w[i], 0 = i = 63
@@ -136,18 +141,18 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 	 * (first 32 bits of the fractional parts of the square roots of the first 8 primes 2..19):
 	 */
 	uint32_t h[] = { 0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab, 0x5be0cd19 };
-	int i, j;
+	int i = 0, j = 0;
 
 	/* 512-bit chunks is what we will operate on. */
-	uint8_t chunk[64];
+	uint8_t chunk[64] = { 0 };
 
-	struct buffer_state state;
+	struct buffer_state state = { 0 };
 
-	init_buf_state(&state, input, len);
+	init_buf_state (&state, input, len);
 
-	while (calc_chunk(chunk, &state)) {
-		uint32_t ah[8];
-		
+	while (calc_chunk (chunk, &state)) {
+		uint32_t ah[8] = { 0 };
+
 		/*
 		 * create a 64-entry message schedule array w[0..63] of 32-bit words
 		 * (The initial values in w[0..63] don't matter, so many implementations zero them here)
@@ -156,7 +161,7 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 		uint32_t w[64];
 		const uint8_t *p = chunk;
 
-		memset(w, 0x00, sizeof w);
+		memset (w, 0x00, sizeof w);
 		for (i = 0; i < 16; i++) {
 			w[i] = (uint32_t) p[0] << 24 | (uint32_t) p[1] << 16 |
 				(uint32_t) p[2] << 8 | (uint32_t) p[3];
@@ -165,21 +170,21 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 
 		/* Extend the first 16 words into the remaining 48 words w[16..63] of the message schedule array: */
 		for (i = 16; i < 64; i++) {
-			const uint32_t s0 = right_rot(w[i - 15], 7) ^ right_rot(w[i - 15], 18) ^ (w[i - 15] >> 3);
-			const uint32_t s1 = right_rot(w[i - 2], 17) ^ right_rot(w[i - 2], 19) ^ (w[i - 2] >> 10);
+			const uint32_t s0 = right_rot (w[i - 15], 7) ^ right_rot (w[i - 15], 18) ^ (w[i - 15] >> 3);
+			const uint32_t s1 = right_rot (w[i - 2], 17) ^ right_rot (w[i - 2], 19) ^ (w[i - 2] >> 10);
 			w[i] = w[i - 16] + s0 + w[i - 7] + s1;
 		}
-		
+
 		/* Initialize working variables to current hash value: */
 		for (i = 0; i < 8; i++)
 			ah[i] = h[i];
 
 		/* Compression function main loop: */
 		for (i = 0; i < 64; i++) {
-			const uint32_t s1 = right_rot(ah[4], 6) ^ right_rot(ah[4], 11) ^ right_rot(ah[4], 25);
+			const uint32_t s1 = right_rot (ah[4], 6) ^ right_rot (ah[4], 11) ^ right_rot (ah[4], 25);
 			const uint32_t ch = (ah[4] & ah[5]) ^ (~ah[4] & ah[6]);
 			const uint32_t temp1 = ah[7] + s1 + ch + k[i] + w[i];
-			const uint32_t s0 = right_rot(ah[0], 2) ^ right_rot(ah[0], 13) ^ right_rot(ah[0], 22);
+			const uint32_t s0 = right_rot (ah[0], 2) ^ right_rot (ah[0], 13) ^ right_rot (ah[0], 22);
 			const uint32_t maj = (ah[0] & ah[1]) ^ (ah[0] & ah[2]) ^ (ah[1] & ah[2]);
 			const uint32_t temp2 = s0 + maj;
 
@@ -199,19 +204,19 @@ void sha_256_calc (uint8_t hash[32], const void * input, size_t len) {
 	}
 
 	/* Produce the final hash value (big-endian): */
-	for (i = 0, j = 0; i < 8; i++)
-	{
+	for (i = 0, j = 0; i < 8; i++) {
 		hash[j++] = (uint8_t) (h[i] >> 24);
 		hash[j++] = (uint8_t) (h[i] >> 16);
 		hash[j++] = (uint8_t) (h[i] >> 8);
 		hash[j++] = (uint8_t) h[i];
 	}
+
 }
 
 void sha_256_hash_to_string (char string[65], const uint8_t hash[32]) {
 
 	size_t i;
-	for (i = 0; i < 32; i++) 
+	for (i = 0; i < 32; i++)
 		string += sprintf(string, "%02x", hash[i]);
-	
-}	
+
+}


### PR DESCRIPTION
## General
- Added base client global init & end methods
- Updated client log methods to work with a pool and internal structures. This was done to prevent memory allocation every time a new log request is made
- Added base log init & end methods
- Updated sources to use new log methods
- Added connection log type

## Client
- Split client_receive () to be able to use an already allocated buffer
- Removed extra check in client_receive_handle_buffer ()

## Connection
- Refactor connection_update () to allocate a packet buffer

## Collections
- Updated pool collection with latest source from cerver

## Fixes
- Fixed errors in files header

## Examples
- Calling client_init () & client_end () in all examples
- Updated examples to use new log methods
- Added logs example